### PR TITLE
Fix typo in feature docs

### DIFF
--- a/docs/features/dm-lock.md
+++ b/docs/features/dm-lock.md
@@ -11,7 +11,7 @@ La fonctionnalité **Fermeture des MP** de RaidProtect permet de fermer l’acc�
 - **Communautés avec un jeune public :** Pour les serveurs comptant un grand nombre de mineurs, limiter les MP peut renforcer la sécurité et prévenir les comportements inappropriés.
 - **Protection continue :** Grâce à l’automatisation, il n’y a pas de fenêtre de vulnérabilité liée à l’oubli du renouvellement manuel.
 
-## ❓ Fonctionnent de la Fermeture des MP {#working}
+## ❓ Fonctionnement de la Fermeture des MP {#working}
 
 Le bot RaidProtect vérifie régulièrement l’état du paramètre de blocage des MP serveur et, si nécessaire, le réactive automatiquement afin d’éviter toute période de vulnérabilité entre deux renouvellements manuels. Cette tâche s’exécute de manière transparente pour les administrateurs et les membres du serveur.
 

--- a/docs/features/reports.md
+++ b/docs/features/reports.md
@@ -4,7 +4,7 @@ title: Signalements
 
 Le système de signalement de RaidProtect permet à votre communauté de signaler rapidement tout contenu problématique ou utilisateur suspect. Il fonctionne de deux manières différentes, et peut être configuré pour optimiser le processus de gestion des signalements.
 
-## ❓ Fonctionnent des signalements {#working}
+## ❓ Fonctionnement des signalements {#working}
 Les membres peuvent signaler un contenu via 3 méthodes principales.
 
 1. **Clic droit sur un message** 

--- a/versioned_docs/version-3.1.0/features/reports.md
+++ b/versioned_docs/version-3.1.0/features/reports.md
@@ -4,7 +4,7 @@ title: Signalements
 
 Le système de signalement de RaidProtect permet à votre communauté de signaler rapidement tout contenu problématique ou utilisateur suspect. Il fonctionne de deux manières différentes, et peut être configuré pour optimiser le processus de gestion des signalements.
 
-## ❓ Fonctionnent des signalements {#working}
+## ❓ Fonctionnement des signalements {#working}
 Les membres peuvent signaler un contenu via 3 méthodes principales.
 
 1. **Clic droit sur un message** 

--- a/versioned_docs/version-3.1.1/features/reports.md
+++ b/versioned_docs/version-3.1.1/features/reports.md
@@ -4,7 +4,7 @@ title: Signalements
 
 Le système de signalement de RaidProtect permet à votre communauté de signaler rapidement tout contenu problématique ou utilisateur suspect. Il fonctionne de deux manières différentes, et peut être configuré pour optimiser le processus de gestion des signalements.
 
-## ❓ Fonctionnent des signalements {#working}
+## ❓ Fonctionnement des signalements {#working}
 Les membres peuvent signaler un contenu via 3 méthodes principales.
 
 1. **Clic droit sur un message** 

--- a/versioned_docs/version-3.2.0/features/dm-lock.md
+++ b/versioned_docs/version-3.2.0/features/dm-lock.md
@@ -11,7 +11,7 @@ La fonctionnalité **Fermeture des MP** de RaidProtect permet de fermer l’acc�
 - **Communautés avec un jeune public :** Pour les serveurs comptant un grand nombre de mineurs, limiter les MP peut renforcer la sécurité et prévenir les comportements inappropriés.
 - **Protection continue :** Grâce à l’automatisation, il n’y a pas de fenêtre de vulnérabilité liée à l’oubli du renouvellement manuel.
 
-## ❓ Fonctionnent de la Fermeture des MP {#working}
+## ❓ Fonctionnement de la Fermeture des MP {#working}
 
 Le bot RaidProtect vérifie régulièrement l’état du paramètre de blocage des MP serveur et, si nécessaire, le réactive automatiquement afin d’éviter toute période de vulnérabilité entre deux renouvellements manuels. Cette tâche s’exécute de manière transparente pour les administrateurs et les membres du serveur.
 

--- a/versioned_docs/version-3.2.0/features/reports.md
+++ b/versioned_docs/version-3.2.0/features/reports.md
@@ -4,7 +4,7 @@ title: Signalements
 
 Le système de signalement de RaidProtect permet à votre communauté de signaler rapidement tout contenu problématique ou utilisateur suspect. Il fonctionne de deux manières différentes, et peut être configuré pour optimiser le processus de gestion des signalements.
 
-## ❓ Fonctionnent des signalements {#working}
+## ❓ Fonctionnement des signalements {#working}
 Les membres peuvent signaler un contenu via 3 méthodes principales.
 
 1. **Clic droit sur un message** 


### PR DESCRIPTION
## Summary
- correct "Fonctionnent" to "Fonctionnement" in documentation
- apply same fix in versioned docs

## Testing
- `npm run build` *(fails: docusaurus not found)*

------
https://chatgpt.com/codex/tasks/task_e_687917f7853083209d5500d257e5c6b8