### PR TITLE
Add German i18n with partial translations

### DIFF
--- a/i18n/de/code.json
+++ b/i18n/de/code.json
@@ -1,0 +1,333 @@
+{
+  "theme.ErrorPageContent.title": {
+    "message": "Diese Seite ist abgestürzt.",
+    "description": "The title of the fallback page when the page crashed"
+  },
+  "theme.BackToTopButton.buttonAriaLabel": {
+    "message": "Nach oben scrollen",
+    "description": "The ARIA label for the back to top button"
+  },
+  "theme.blog.archive.title": {
+    "message": "Archiv",
+    "description": "The page & hero title of the blog archive page"
+  },
+  "theme.blog.archive.description": {
+    "message": "Archiv",
+    "description": "The page & hero description of the blog archive page"
+  },
+  "theme.blog.paginator.navAriaLabel": {
+    "message": "Navigation der Blogseite",
+    "description": "The ARIA label for the blog pagination"
+  },
+  "theme.blog.paginator.newerEntries": {
+    "message": "Neuere Einträge",
+    "description": "The label used to navigate to the newer blog posts page (previous page)"
+  },
+  "theme.blog.paginator.olderEntries": {
+    "message": "Ältere Einträge",
+    "description": "The label used to navigate to the older blog posts page (next page)"
+  },
+  "theme.blog.post.paginator.navAriaLabel": {
+    "message": "Navigation der Blogbeiträge",
+    "description": "The ARIA label for the blog posts pagination"
+  },
+  "theme.blog.post.paginator.newerPost": {
+    "message": "Neuerer Beitrag",
+    "description": "The blog post button label to navigate to the newer/previous post"
+  },
+  "theme.blog.post.paginator.olderPost": {
+    "message": "Älterer Beitrag",
+    "description": "The blog post button label to navigate to the older/next post"
+  },
+  "theme.tags.tagsPageLink": {
+    "message": "Alle Tags anzeigen",
+    "description": "The label of the link targeting the tag list page"
+  },
+  "theme.colorToggle.ariaLabel": {
+    "message": "Zwischen dunklem und hellem Modus wechseln (aktuell {mode})",
+    "description": "The ARIA label for the color mode toggle"
+  },
+  "theme.colorToggle.ariaLabel.mode.dark": {
+    "message": "dunkler Modus",
+    "description": "The name for the dark color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.light": {
+    "message": "heller Modus",
+    "description": "The name for the light color mode"
+  },
+  "theme.docs.breadcrumbs.navAriaLabel": {
+    "message": "Brotkrumen",
+    "description": "The ARIA label for the breadcrumbs"
+  },
+  "theme.docs.DocCard.categoryDescription.plurals": {
+    "message": "1 Element|{count} Elemente",
+    "description": "The default description for a category card in the generated index about how many items this category includes"
+  },
+  "theme.docs.paginator.navAriaLabel": {
+    "message": "Dokumentationsseiten",
+    "description": "The ARIA label for the docs pagination"
+  },
+  "theme.docs.paginator.previous": {
+    "message": "Zurück",
+    "description": "The label used to navigate to the previous doc"
+  },
+  "theme.docs.paginator.next": {
+    "message": "Weiter",
+    "description": "The label used to navigate to the next doc"
+  },
+  "theme.docs.tagDocListPageTitle.nDocsTagged": {
+    "message": "Ein Dokument markiert|{count} Dokumente markiert",
+    "description": "Pluralized label for \"{count} docs tagged\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.tagDocListPageTitle": {
+    "message": "{nDocsTagged} with \"{tagName}\"",
+    "description": "The title of the page for a docs tag"
+  },
+  "theme.docs.versionBadge.label": {
+    "message": "Version: {versionLabel}"
+  },
+  "theme.docs.versions.unreleasedVersionLabel": {
+    "message": "This is unreleased documentation for {siteTitle} {versionLabel} version.",
+    "description": "The label used to tell the user that he's browsing an unreleased doc version"
+  },
+  "theme.docs.versions.unmaintainedVersionLabel": {
+    "message": "This is documentation for {siteTitle} {versionLabel}, which is no longer actively maintained.",
+    "description": "The label used to tell the user that he's browsing an unmaintained doc version"
+  },
+  "theme.docs.versions.latestVersionSuggestionLabel": {
+    "message": "For up-to-date documentation, see the {latestVersionLink} ({versionLabel}).",
+    "description": "The label used to tell the user to check the latest version"
+  },
+  "theme.docs.versions.latestVersionLinkLabel": {
+    "message": "latest version",
+    "description": "The label used for the latest version suggestion link label"
+  },
+  "theme.common.editThisPage": {
+    "message": "Edit this page",
+    "description": "The link label to edit the current page"
+  },
+  "theme.common.headingLinkTitle": {
+    "message": "Direct link to {heading}",
+    "description": "Title for link to heading"
+  },
+  "theme.lastUpdated.atDate": {
+    "message": " on {date}",
+    "description": "The words used to describe on which date a page has been last updated"
+  },
+  "theme.lastUpdated.byUser": {
+    "message": " by {user}",
+    "description": "The words used to describe by who the page has been last updated"
+  },
+  "theme.lastUpdated.lastUpdatedAtBy": {
+    "message": "Last updated{atDate}{byUser}",
+    "description": "The sentence used to display when a page has been last updated, and by who"
+  },
+  "theme.navbar.mobileVersionsDropdown.label": {
+    "message": "Versions",
+    "description": "The label for the navbar versions dropdown on mobile view"
+  },
+  "theme.NotFound.title": {
+    "message": "Error ",
+    "description": "The title of the 404 page"
+  },
+  "theme.tags.tagsListLabel": {
+    "message": "Tags:",
+    "description": "The label alongside a tag list"
+  },
+  "theme.admonition.caution": {
+    "message": "caution",
+    "description": "The default label used for the Caution admonition (:::caution)"
+  },
+  "theme.admonition.danger": {
+    "message": "danger",
+    "description": "The default label used for the Danger admonition (:::danger)"
+  },
+  "theme.admonition.info": {
+    "message": "info",
+    "description": "The default label used for the Info admonition (:::info)"
+  },
+  "theme.admonition.note": {
+    "message": "note",
+    "description": "The default label used for the Note admonition (:::note)"
+  },
+  "theme.admonition.tip": {
+    "message": "tip",
+    "description": "The default label used for the Tip admonition (:::tip)"
+  },
+  "theme.admonition.warning": {
+    "message": "warning",
+    "description": "The default label used for the Warning admonition (:::warning)"
+  },
+  "theme.AnnouncementBar.closeButtonAriaLabel": {
+    "message": "Close",
+    "description": "The ARIA label for close button of announcement bar"
+  },
+  "theme.blog.sidebar.navAriaLabel": {
+    "message": "Blog recent posts navigation",
+    "description": "The ARIA label for recent posts in the blog sidebar"
+  },
+  "theme.CodeBlock.copied": {
+    "message": "Copied",
+    "description": "The copied button label on code blocks"
+  },
+  "theme.CodeBlock.copyButtonAriaLabel": {
+    "message": "Copy code to clipboard",
+    "description": "The ARIA label for copy code blocks button"
+  },
+  "theme.CodeBlock.copy": {
+    "message": "Copy",
+    "description": "The copy button label on code blocks"
+  },
+  "theme.CodeBlock.wordWrapToggle": {
+    "message": "Toggle word wrap",
+    "description": "The title attribute for toggle word wrapping button of code block lines"
+  },
+  "theme.DocSidebarItem.expandCategoryAriaLabel": {
+    "message": "Expand sidebar category '{label}'",
+    "description": "The ARIA label to expand the sidebar category"
+  },
+  "theme.DocSidebarItem.collapseCategoryAriaLabel": {
+    "message": "Collapse sidebar category '{label}'",
+    "description": "The ARIA label to collapse the sidebar category"
+  },
+  "theme.NavBar.navAriaLabel": {
+    "message": "Main",
+    "description": "The ARIA label for the main navigation"
+  },
+  "theme.navbar.mobileLanguageDropdown.label": {
+    "message": "Languages",
+    "description": "The label for the mobile language switcher dropdown"
+  },
+  "theme.NotFound.p1": {
+    "message": "The page you are looking for does not exist or has been moved.",
+    "description": "The first paragraph of the 404 page"
+  },
+  "theme.TOCCollapsible.toggleButtonLabel": {
+    "message": "On this page",
+    "description": "The label used by the button on the collapsible TOC component"
+  },
+  "theme.blog.post.readMore": {
+    "message": "Read more",
+    "description": "The label used in blog post item excerpts to link to full blog posts"
+  },
+  "theme.blog.post.readMoreLabel": {
+    "message": "Read more about {title}",
+    "description": "The ARIA label for the link to full blog posts from excerpts"
+  },
+  "theme.blog.post.readingTime.plurals": {
+    "message": "One min read|{readingTime} min read",
+    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.breadcrumbs.home": {
+    "message": "Home page",
+    "description": "The ARIA label for the home page in the breadcrumbs"
+  },
+  "theme.docs.sidebar.collapseButtonTitle": {
+    "message": "Collapse sidebar",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.collapseButtonAriaLabel": {
+    "message": "Collapse sidebar",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.navAriaLabel": {
+    "message": "Docs sidebar",
+    "description": "The ARIA label for the sidebar navigation"
+  },
+  "theme.docs.sidebar.closeSidebarButtonAriaLabel": {
+    "message": "Close navigation bar",
+    "description": "The ARIA label for close button of mobile sidebar"
+  },
+  "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
+    "message": "← Back to main menu",
+    "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
+  },
+  "theme.docs.sidebar.toggleSidebarButtonAriaLabel": {
+    "message": "Toggle navigation bar",
+    "description": "The ARIA label for hamburger menu button of mobile navigation"
+  },
+  "theme.docs.sidebar.expandButtonTitle": {
+    "message": "Expand sidebar",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.sidebar.expandButtonAriaLabel": {
+    "message": "Expand sidebar",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.blog.post.plurals": {
+    "message": "One post|{count} posts",
+    "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.tagTitle": {
+    "message": "{nPosts} tagged with \"{tagName}\"",
+    "description": "The title of the page for a blog tag"
+  },
+  "theme.blog.author.pageTitle": {
+    "message": "{authorName} - {nPosts}",
+    "description": "The title of the page for a blog author"
+  },
+  "theme.blog.authorsList.pageTitle": {
+    "message": "Authors",
+    "description": "The title of the authors page"
+  },
+  "theme.blog.authorsList.viewAll": {
+    "message": "View all authors",
+    "description": "The label of the link targeting the blog authors page"
+  },
+  "theme.blog.author.noPosts": {
+    "message": "This author has not written any posts yet.",
+    "description": "The text for authors with 0 blog post"
+  },
+  "theme.contentVisibility.unlistedBanner.title": {
+    "message": "Unlisted page",
+    "description": "The unlisted content banner title"
+  },
+  "theme.contentVisibility.unlistedBanner.message": {
+    "message": "This page is unlisted. Search engines will not index it, and only users having a direct link can access it.",
+    "description": "The unlisted content banner message"
+  },
+  "theme.contentVisibility.draftBanner.title": {
+    "message": "Draft page",
+    "description": "The draft content banner title"
+  },
+  "theme.contentVisibility.draftBanner.message": {
+    "message": "This page is a draft. It will only be visible in dev and be excluded from the production build.",
+    "description": "The draft content banner message"
+  },
+  "theme.ErrorPageContent.tryAgain": {
+    "message": "Try again",
+    "description": "The label of the button to try again rendering when the React error boundary captures an error"
+  },
+  "theme.common.skipToMainContent": {
+    "message": "Skip to main content",
+    "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
+  },
+  "theme.tags.tagsPageTitle": {
+    "message": "Tags",
+    "description": "The title of the tag list page"
+  },
+  "theme.NotFound.backToHome": {
+    "message": "Back To Home",
+    "description": "Back to home button on 404 page"
+  },
+  "theme.NotFound.goBack": {
+    "message": "Go back",
+    "description": "Back to previous page button on 404 page"
+  },
+  "theme.NotFound.p2": {
+    "message": "Please contact the owner of the site that linked you to the original URL and let them know their link is broken.",
+    "description": "The 2nd paragraph of the 404 page"
+  },
+  "theme.colorToggle.ariaLabel.mode.system": {
+    "message": "system mode",
+    "description": "The name for the system color mode"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.expandAriaLabel": {
+    "message": "Expand the dropdown",
+    "description": "The ARIA label of the button to expand the mobile dropdown navbar item"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.collapseAriaLabel": {
+    "message": "Collapse the dropdown",
+    "description": "The ARIA label of the button to collapse the mobile dropdown navbar item"
+  }
+}

--- a/i18n/de/docusaurus-plugin-content-blog/3.1.0/3.1.0-interactions-update.md
+++ b/i18n/de/docusaurus-plugin-content-blog/3.1.0/3.1.0-interactions-update.md
@@ -1,0 +1,74 @@
+---
+title: 'Interactions Update (3.1.0)'
+tags: [release, language]
+authors: [derrios, zallom]
+image: ./assets/rp-interactions-update.webp
+slug: 3.1.0-interactions-update
+date: 2025-03-12
+---
+
+It’s been a while since we last released a major update for RaidProtect, and we sincerely apologize for the long wait. Over the past few months, we’ve been working hard to modernize and improve the bot experience. Today, we’re excited to introduce the **Interactions Update**!
+
+![RaidProtect Interactions Update blog post social card](./assets/rp-interactions-update.webp)
+
+<!--truncate-->
+
+## ✨ What's Changing (And It’s a Lot) {#new}
+
+This update marks a turning point in the way RaidProtect works, focusing on **interaction and user-friendliness**, especially with the introduction of **slash commands** and a **revamped configuration system**. 
+
+Additionally, we’ve listened to <a href="https://suggestions.raidprotect.bot" target="_blank">your feedback and ideas</a>, and this update includes many features you requested! You can also [check out the changelog](/changelog) to see which suggestions have been implemented.
+
+### Slash Commands {#slash-commands}
+
+Yes, you’ve been waiting for them for a long time… So have we. Say goodbye to outdated text commands and hello to slash commands! Simpler, faster, and making RaidProtect finally worthy of 2021 (yes, we know, it’s already 2025).
+
+No worries for long-time users—text commands are still available, and now you can even set your own custom prefix!
+
+### Internationalization (RP Goes Bilingual) {#internationalization}
+
+We’ve laid the groundwork for a [**multilingual system**](/language) and added English as the second official language! More languages will be added in the future.
+
+### A Reporting Command {#report}
+
+A long-requested feature: [**a reporting system**](/features/reports) that allows your community to easily report incidents on your server.
+
+![Screenshot of the report menu](./assets/rp-report-message.webp)
+
+### New Configuration Commands {#configuration}
+
+We know that setting up a bot can quickly become a headache, so we’ve made it much simpler:
+- **An interactive panel with [`/settings`](/setup#settings)** to manage RaidProtect at a glance.
+- **A brand-new [`/setup`](/setup#install)** to guide you right from the installation process.
+- **More flexible options** for fine-tuned configuration.
+
+![Screenshot of the configuration menu](./assets/rp-configuration-menu.webp)
+
+### A Better User Experience {#ux}
+
+Alongside these new features, we’ve improved overall usability:
+- A smarter, better-integrated captcha.
+- Automatic detection of permission errors.
+- Clearer and more consistent messages.
+
+### Website and Documentation Update {#web}
+
+In addition to bot improvements, we’ve also updated **the website and documentation** to make information more accessible and structured. Feel free to check it out!
+
+## 🔎 What's Next? {#next}
+
+This update is just the first step toward an even more advanced version of RaidProtect. More improvements are already in the works, and we can't wait to share them with you!
+
+To see what’s coming next, <a href="https://suggestions.raidprotect.bot/roadmap" target="_blank">take a look at our roadmap</a>.
+
+:::tip Join the Conversation!
+Want to follow RaidProtect’s development in real time, share your thoughts on future features, or just chat with the community? <a href="https://raidprotect.bot/discord" target="_blank">Join our Discord server!</a>
+:::
+
+---
+
+## ❤️ Thank You for Your Patience (Seriously) {#thanks}
+
+We know, this update took a while. Huge thanks to everyone who supported us and waited patiently (or not 😆).
+
+A special thanks to everyone who shared their <a href="https://suggestions.raidprotect.bot" target="_blank">ideas and suggestions</a>, your input was invaluable in shaping this update! Keep sending us your feedback, and we promise to be quicker next time (well, we’ll try).

--- a/i18n/de/docusaurus-plugin-content-blog/3.1.1/3.1.1-tag-role.md
+++ b/i18n/de/docusaurus-plugin-content-blog/3.1.1/3.1.1-tag-role.md
@@ -1,0 +1,67 @@
+---
+title: 'An Automatic Role Linked to the Server Tag (3.1.1)'
+tags: [release]
+authors: [derrios]
+image: ./assets/rp-tag-role.webp
+slug: 3.1.1-tag-role
+date: 2025-05-21
+---
+
+Looking to automatically assign a **Discord tag role** to your members? Want to give a role when someone wears your **Discord server tag**? Good news: RaidProtect 3.1.1 introduces the **Tag Role** feature.
+
+![RaidProtect Tag Role blog post social card](./assets/rp-tag-role.webp)
+
+<!--truncate-->
+
+## 🎉 New: An Automatic Discord Tag Role {#new}
+
+Thanks to this update, you can now **assign a role as soon as a member adds your server tag** to their Discord profile. And if the tag is removed, the role is automatically taken away. Convenient, efficient, and 100% automated.
+
+This feature allows you to:
+- **Reward** members who actively represent your community.
+- **Strengthen cohesion** and internal recognition on the server.
+- **Easily identify** your ambassadors and engaged members.
+
+💡 **How it works:**  
+As soon as a user adds the **guild tag** to their profile, the RaidProtect bot automatically assigns them the role you've configured. And conversely, if the tag is removed, the role is too.  
+➡️ More details in [our documentation](/features/tag-role).
+
+---
+
+## 🛠️ Additional New Features in Version 3.1.1 {#changelog}
+
+Besides the **Discord guild tag role**, this version brings other key improvements:
+
+- **New moderation command [`/timeout`](/features/moderation#timeout)**  
+  Lets you temporarily exclude a member without banning them—ideal for managing short-term inappropriate behavior. The command lets you choose a more precise and longer duration (up to 28 days) than Discord's default options.
+
+- **Automatic update tracking**  
+  Receive alerts directly in your log channel (updates, incidents, fixes). More responsiveness, more clarity.
+
+- **Various optimizations and fixes**  
+  Numerous internal improvements ensure better performance and stability.  
+  ➕ Check the [full changelog](/changelog#3-1-1) for all the details.
+
+---
+
+## ❓ FAQ: Automatic Role Linked to Discord Tags {#faq}
+
+### Which bot can automate roles based on Discord tags? {#which-bot}
+
+With RaidProtect, simply configure a **role based on the Discord tag**. As soon as a member adds the tag to their Discord profile, the role is automatically assigned. If the tag is removed, the role disappears as well.
+
+### How do I add a role with a Discord tag? {#how-to}
+
+1. Install RaidProtect on your server.
+2. Go to the tag-based roles configuration.
+3. Define the role to assign when a user has the guild tag.
+4. Save your changes.
+
+From then on, management is fully automatic.
+
+:::tip 📚 Useful resources
+- 🔗 [Add RaidProtect to your server](https://raidprotect.bot/invite)
+- 📘 [Read the full documentation](https://docs.raidprotect.bot/)
+- 💡 [Submit feedback or suggestions](https://suggestions.raidprotect.bot/)
+- 📣 [Follow announcements and join the community](https://raidprotect.bot/discord)
+:::

--- a/i18n/de/docusaurus-plugin-content-blog/3.2.0/3.2.0-protection-update.md
+++ b/i18n/de/docusaurus-plugin-content-blog/3.2.0/3.2.0-protection-update.md
@@ -1,0 +1,47 @@
+---
+title: 'Protection Update (3.2.0)'
+tags: [release]
+authors: [derrios]
+image: ./assets/rp-protection-update.webp
+slug: 3.2.0-protection-update
+date: 2025-07-10
+---
+
+Version 3.2.0 marks a major milestone for the security of your Discord community with the introduction of DM Lock – an all-new shield against spam, scams, and private message fraud.
+
+![RaidProtect Protection Update blog post social card](./assets/rp-protection-update.webp)
+
+<!--truncate-->
+
+## 🛡️ No more private message scams! {#new}
+
+Protect your members by automatically blocking the receipt of private messages with [DM Lock](/features/dm-lock). Typical use cases:
+
+- Automated spam waves during events (launches, giveaways, high-traffic periods).
+- Scam attempts targeting members, especially on large public servers.
+- Inappropriate behavior toward minors or sensitive communities.
+- Coordinated attacks during major events (raids, phishing campaigns).
+
+All fully automated, with no risk of forgetting manual steps, ensuring continuous protection for your server.
+
+---
+
+## ✨ Other new features in 3.2.0 {#changelog}
+
+- **Choice of [anti-spam sanctions](/features/anti-spam#triggers)**: Precisely define how RaidProtect responds to different types of spam (kick, ban...), for moderation perfectly tailored to your community.
+- **New [anti-spam logs](/features/anti-spam#logs)**: More visibility on what is detected and when, keeping you in control at a glance.
+- **[Minimum account age](/features/raid-mode#minage) without captcha**: Directly filter out brand-new members even if captcha is not enabled.
+- **[`/bypass minage`](/features/raid-mode#bypass-minage) command**: Manually admit a member who doesn’t meet the required account age, handy for exceptional cases.
+- **Complete redesign of [`/userinfo`](/features/utilities#userinfo)**: Improved interface, clearer and more complete information.
+- **Configuration logs**: Increased traceability for every major change to the bot’s settings.
+
+---
+
+For the full list of new features, fixes, and technical details, see the [official changelog](/changelog#3-2-0).
+
+:::tip 📚 Useful resources
+- 🔗 [Add RaidProtect to your server](https://raidprotect.bot/invite)
+- 📘 [Read the full documentation](https://docs.raidprotect.bot/)
+- 💡 [Submit a suggestion or feedback](https://suggestions.raidprotect.bot/)
+- 📣 [Follow announcements and join the community](https://raidprotect.bot/discord)
+:::

--- a/i18n/de/docusaurus-plugin-content-blog/authors.yml
+++ b/i18n/de/docusaurus-plugin-content-blog/authors.yml
@@ -1,0 +1,29 @@
+derrios:
+  name: Arthur
+  title: Administrator
+  url: https://fca.gg/en/team/arthur
+  page: false
+  image_url: https://github.com/mrderrios.png
+  socials: {
+    linkedin: arthurbattais,
+    github: MrDerrios
+  }
+zallom:
+  name: Zallom
+  title: Lead Developer
+  url: https://zallom.fr
+  page: false
+  image_url: https://github.com/zallom.png
+  socials: {
+    linkedin: matthias-gp,
+    github: Zallom
+  }
+ichii:
+  name: Ethan
+  title: Developer
+  url: https://github.com/IchiiDev
+  page: false
+  image_url: https://github.com/ichiidev.png
+  socials: {
+    github: IchiiDev
+  }

--- a/i18n/de/docusaurus-plugin-content-blog/beta-program-launch.md
+++ b/i18n/de/docusaurus-plugin-content-blog/beta-program-launch.md
@@ -1,0 +1,61 @@
+---
+title: 'Start des Beta-Programms'
+tags: [community]
+authors: [derrios]
+slug: beta-program-launch
+date: 2024-11-25
+---
+
+Wir haben großartige Neuigkeiten für die RaidProtect‑Community: **das BETA‑Programm ist offiziell gestartet**! 🎉
+
+Wir möchten unseren Qualitätsanspruch noch weiter vorantreiben und euch direkt einbeziehen. Dieses Programm gibt euch frühzeitigen Zugriff auf kommende Bot‑Funktionen und hilft uns dabei, sie vor der öffentlichen Veröffentlichung zu testen.
+
+<!--truncate-->
+
+## Warum ein Beta‑Programm? {#why-beta}
+
+Die Entwicklung eines Bots wie RaidProtect erfordert zahlreiche Tests, Anpassungen und Kontrollen. Mit diesem Beta‑Programm verfolgen wir zwei Hauptziele:
+
+- **Neue Funktionen unter realen Bedingungen testen**.
+- **Direktes Feedback** aus der Community erhalten, um die Nutzererfahrung kontinuierlich zu verbessern.
+
+Und das Beste? **Premium‑Funktionen** sind während der Testphase auf ausgewählten Servern kostenlos enthalten. 😍
+
+## Was ist derzeit enthalten? {#features-beta}
+
+Das Beta‑Programm verschafft euch frühen Zugang zu mehreren neuen Funktionen, die bereits in der Testversion verfügbar sind:
+
+- 🧵 **Slash‑Befehle und Button‑Interaktionen**: für ein modernes Benutzererlebnis.
+- 🌍 **Internationalisierung**: Der Bot spricht nun sowohl Französisch *als auch* Englisch.
+- 📢 **Neuer `/report`‑Befehl**: problematisches Verhalten leicht melden.
+- 🛡️ **Rollen oder Nutzer im Antispam ignorieren**: für mehr Flexibilität.
+- 🔒 **Option Kanäle über `/lock` umzubenennen**: Sicherheit individuell anpassen.
+- 🔧 **Stabilitätsverbesserungen**: weniger Bugs, mehr Zuverlässigkeit.
+
+Diese Funktionen werden nach erfolgreicher Validierung durch die Beta‑Tester öffentlich ausgerollt.
+
+## Wer kann teilnehmen? {#who}
+
+Jeder kann sich bewerben, sofern er einen aktiven Discord‑Server verwaltet und bereit ist, neue Funktionen zu testen. Ein paar Voraussetzungen:
+
+- **Regelmäßige Aktivität** ist erforderlich.
+- **Halte deine DMs offen**, damit wir dich kontaktieren können.
+- Bei längerer Inaktivität können wir deinen Beta‑Zugang entziehen.
+
+## Wie kann man teilnehmen? {#how}
+
+Nichts leichter als das: Fülle unser Bewerbungsformular aus (dauert weniger als 5 Minuten) unter folgendem Link:
+
+👉 [https://raidprotect.bot/beta](https://raidprotect.bot/beta)
+
+Wir prüfen alle Bewerbungen sorgfältig. Wenn du ausgewählt wirst, kontaktieren wir dich über Discord.
+
+---
+
+## Vielen Dank für eure Unterstützung 💙 {#thanks}
+
+RaidProtect ist vor allem ein Community‑Projekt. Euer Feedback und eure Beteiligung sind entscheidend, damit sich der Bot in die richtige Richtung entwickelt. Danke an alle, die bereits Teil dieses Beta‑Abenteuers sind, und willkommen an diejenigen, die noch dazukommen!
+
+:::tip
+Du möchtest über die neuesten Neuigkeiten auf dem Laufenden bleiben oder Fragen stellen? Tritt unserem [offiziellen Discord‑Server](https://raidprotect.bot/discord) bei!
+:::

--- a/i18n/de/docusaurus-plugin-content-blog/options.json
+++ b/i18n/de/docusaurus-plugin-content-blog/options.json
@@ -1,0 +1,14 @@
+{
+  "title": {
+    "message": "Blog",
+    "description": "The title for the blog used in SEO"
+  },
+  "description": {
+    "message": "",
+    "description": "The description for the blog used in SEO"
+  },
+  "sidebar.title": {
+    "message": "Blog",
+    "description": "The label for the left sidebar"
+  }
+}

--- a/i18n/de/docusaurus-plugin-content-blog/tags.yml
+++ b/i18n/de/docusaurus-plugin-content-blog/tags.yml
@@ -1,0 +1,8 @@
+release:
+  label: Veröffentlichung
+language:
+  label: Sprache
+faq:
+  label: FAQ
+community:
+  label: Community

--- a/i18n/de/docusaurus-plugin-content-blog/transition-faq.md
+++ b/i18n/de/docusaurus-plugin-content-blog/transition-faq.md
@@ -1,0 +1,67 @@
+---
+title: 'A New Era for Your Security'
+tags: [faq]
+authors: [derrios, ichii]
+date: 2023-01-16
+---
+
+Since its creation in 2018 by [Baptiste](https://baptiste.lol/), RaidProtect has become one of the essential French-speaking bots for Discord server security. After more than four years of development and evolution, the project is now undergoing a major transition: **RaidProtect is being taken over by the team behind [S*l*ash FR](https://slash.fr.community/) and [DFR.gg](https://dfr.gg/)**. This takeover aims to secure the bot’s future, offer new perspectives, and enrich its development.
+
+<!--truncate-->
+
+## Why this takeover? {#why}
+
+Over time, maintaining a bot like RaidProtect became increasingly complicated. Between Discord’s changes, API updates, and growing demands, it was becoming harder and harder for Baptiste to keep RaidProtect up to date while ensuring its stability and effectiveness. Rather than let RaidProtect shut down, he chose to entrust the project to us.
+
+Our team has taken over, bringing the resources and expertise needed to meet the technical and organizational challenges of RaidProtect. Our goal is simple: to improve and modernize the bot while staying true to what it has always been.
+
+## What’s changing (and what’s not!) {#changing}
+
+#### ✅ RaidProtect is still the same bot you know {#same}
+The features you rely on aren’t going anywhere. We’re keeping **the same philosophy**, and we just want to make it better without disrupting your habits. Security and reliability remain at the heart of the project.
+
+#### 🔄 A technical overhaul for better performance {#technical-overhaul}
+The bot has been completely rewritten to be faster, more stable, and better suited to Discord’s changes. This overhaul wasn’t just an improvement — it was a necessity: with the new version of Discord’s API, the old version of the bot simply would no longer function. This update also makes it easier for us to add new features.
+
+#### 🛠️ Updates and new features coming soon {#updates}
+One of the major benefits of this takeover is that we can finally invest time and resources into making RaidProtect even more effective. Here are some of the upcoming improvements:
+- Support for **slash commands** to align with Discord’s current standards.
+- More **configuration options** to fit each server’s needs.
+- A **multilingual system** to broaden RaidProtect’s reach.
+
+#### 🔐 A stronger commitment to security {#safety}
+RaidProtect was designed to protect servers, and that remains our top priority. We will closely monitor Discord’s evolution and adapt the bot to the new tools the platform provides.
+
+## Your questions, our answers (FAQ) {#faq}
+
+When we announced the takeover of RaidProtect, we received many questions from the community. Whether on the support server or during our transition event, we saw strong interest in the bot’s future. To clarify things and provide clear answers, we’ve gathered the most frequently asked questions here.
+
+#### Who are you and why you? {#faq-1}
+
+More than just a team, we’re a group of friends who have been combining passion and expertise to build online communities since 2017. We also launched S*l*ash FR, a French-speaking community focused on Discord and its best practices. RaidProtect naturally fits into this ecosystem.
+
+We understand that the idea of a company behind the project may worry some people. To be honest, yes, we will have to fund RaidProtect, because running a bot at this scale is expensive. But we don’t want to limit the bot or turn everything into paid features. All current features will remain free, and premium options will be available for those who want advanced tools.
+
+#### Why is your agency taking over RaidProtect? {#faq-2}
+Our agency specializes in managing Discord servers and developing bots. The team wanted to invest in a major project, and RaidProtect perfectly matched that ambition.
+
+#### What’s the link with S*l*ash FR? {#faq-3}
+S*l*ash FR is a community we created to bring together Discord enthusiasts. RaidProtect naturally fits in, but it remains an independent project.
+
+#### Will the current RaidProtect team change? {#faq-4}
+No, most of the community team is continuing the journey, supported by new members from S*l*ash FR. Baptiste himself will still provide occasional support on the project.
+
+#### Will the bot become paid? {#faq-5}
+All current features will **remain free**. However, some new advanced features may be offered through a premium subscription to cover maintenance and development costs.
+
+#### Will the design and branding of RaidProtect change? {#faq-6}
+No, RaidProtect’s visual identity will **stay the same**. However, the website will be updated to better reflect the project’s evolution.
+
+#### Will your team develop other bots? {#faq-7}
+The acquisition of RaidProtect is part of a broader plan to eventually offer other tools for Discord servers. However, the current priority is to optimize and perfect RaidProtect.
+
+---
+
+RaidProtect is evolving, but the spirit remains the same. We know how important this bot is for many servers, and we want to make it an even more reliable, powerful, and adaptable tool for your needs.
+
+Thank you all for your trust — the adventure is just beginning! 🚀

--- a/i18n/de/docusaurus-plugin-content-docs/current.json
+++ b/i18n/de/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,34 @@
+{
+  "version.label": {
+    "message": "Beta 🚧",
+    "description": "The label for version current"
+  },
+  "sidebar.sidebar.category.features": {
+    "message": "Funktionen",
+    "description": "The label for category features in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.guides": {
+    "message": "Anleitungen",
+    "description": "The label for category guides in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.useful-links": {
+    "message": "Nützliche Links",
+    "description": "The label for category useful-links in sidebar sidebar"
+  },
+  "sidebar.sidebar.link.invite": {
+    "message": "RaidProtect einladen",
+    "description": "The label for link invite in sidebar sidebar, linking to https://raidprotect.bot/invite"
+  },
+  "sidebar.sidebar.link.discord": {
+    "message": "Discord-Server",
+    "description": "The label for link discord in sidebar sidebar, linking to https://raidprotect.bot/discord"
+  },
+  "sidebar.sidebar.link.suggest": {
+    "message": "Funktion vorschlagen",
+    "description": "The label for link suggest in sidebar sidebar, linking to https://suggestions.raidprotect.bot"
+  },
+  "sidebar.sidebar.link.report": {
+    "message": "Einen Verstoß an Discord melden",
+    "description": "The label for link report in sidebar sidebar, linking to https://discord.com/safety/360044103651-reporting-abusive-behavior-to-discord"
+  }
+}

--- a/i18n/de/docusaurus-plugin-content-docs/current/changelog.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/changelog.mdx
@@ -1,0 +1,126 @@
+---
+title: Changelog
+---
+
+import SuggestionLink from '@site/src/components/SuggestionLink';
+
+Discover the detailed list of changes made to RaidProtect.
+
+## 3.2.0 (10/07/2025) {#3-2-0}
+
+- New feature [DM Lock](./features/dm-lock.mdx).
+- Choice of [sanctions](./features/anti-spam.mdx#triggers) applied by anti-spam. <SuggestionLink id="85" />
+- New [anti-spam logs](./features/anti-spam.mdx#logs) (more visibility on detections).
+- Activation of a [minimum account age](./features/raid-mode.md#minage) without captcha. <SuggestionLink id="314" />
+- New [command /bypass minage](./features/raid-mode.md#bypass-minage) to accept a user who doesn’t meet the required account age. <SuggestionLink id="447" />
+- Complete overhaul of the [command `/userinfo`](./features/utilities.mdx#userinfo).
+- New logs for important bot configuration changes.
+- Fixes:
+  - Anti-spam now works in threads.
+  - The [command `/lock`](./features/channel-lock.md) now supports forum and media channels, and blocks threads with the channels.
+  - The [captcha](./features/captcha.md) no longer blocks new members when the bot does not have the necessary permissions.
+  - Fixed the bug with the [command `/clear`](./features/moderation.md#clear) when the bot lacked the necessary permissions in a channel.
+- Improved UI/UX:
+  - Clarification on the ability to type in the member, role, and channel select menus.
+  - Check for the presence of the `COMMUNITY` feature when configuring Auto Raid Mode.
+- Performance and stability:
+  - Revamped emoji management ([`@fca.gg/glyph` v1.0.0](https://github.com/FCAgreatgoals/glyph)).
+  - Reduced startup time and cluster monitoring (`@fca.gg/midway` v1.3.1).
+  - Better rate limit handling and reduced latency (`@fca.gg/iris` v1.1.4).
+  - Integrated Sentry for error tracking and improved dev support ([`@fca.gg/kino` v1.0.0](https://github.com/FCAgreatgoals/kino)).
+
+## 3.1.1 (21/05/2025) {#3-1-1}
+
+- New feature [Role Tag](./features/tag-role.md). <SuggestionLink id="512" />
+- New moderation command [`/timeout`](./features/moderation.md#timeout). <SuggestionLink id="52" />
+- Automatic tracking of updates in each server's general log room.
+- Performance and stability:
+  - Cleanup of persistent antispam states.
+  - Fixed memory leaks.
+  - Optimized database calls.
+  - Improved overall bot speed.
+
+## 3.1.0 (12/03/2025) {#3-1-0}
+
+- Added **Slash Commands**. <SuggestionLink id="463" />
+- [Internationalization](./language.md) (added English). <SuggestionLink id="109" />
+- New feature [`/report`](./features/reports.md). <SuggestionLink id="164" />
+- New configuration commands:
+  - [`/settings`](./setup.md#settings) as an interactive panel.
+  - [`/setup`](./setup.md#install) as an Onboarding process.
+- Advanced settings:
+  - Enable/disable each feature individually. <SuggestionLink id="356" />
+  - Choose the delay and number of attempts before expulsion by the [captcha](./features/captcha.md#config). <SuggestionLink id="363" />
+  - Option to select the verification channel for the [captcha](./features/captcha.md). <SuggestionLink id="385" />
+  - Ignore users/roles/categories in the [anti-spam](./features/anti-spam.mdx#ignore). <SuggestionLink id="362" />
+  - Choose the [prefix for hybrid commands](./guides/prefix.md). <SuggestionLink id="103" />
+  - Option to choose whether the [`/lock` command](./features/channel-lock.md) renames the locked channel with `🔒`.
+- Improved UX:
+  - Prefix displayed when pinging the bot + mention as a universal prefix. <SuggestionLink id="193" />
+  - Disabling the [captcha](./features/captcha.md) no longer deletes the associated role and channel. <SuggestionLink id="43" />
+  - Automatic detection of permission issues related to channels and roles. <SuggestionLink id="65" />
+  - Automatic visibility check of the verification channel in Discord's onboarding process.
+  - Standardized messages.
+- Improved bot performance and stability.
+
+## 3.0.0 (01/14/2023) {#3-0-0}
+
+- Complete rewrite aimed at preparing for future updates and stabilizing the bot.
+- Fixed all known bugs to date.
+- The [`?raidmode` command](./features/raid-mode.md) now uses the "Disable Invites" feature.
+- Automatic sending of a private message to the concerned member when a sanction is applied. <SuggestionLink id="426" />
+
+## 2.2.0 (04/13/2020) {#2-2-0}
+
+- Improved bot performance.
+- Significant changes to the project's internal architecture.
+
+## 2.1.3 (10/13/2019) {#2-1-3}
+
+- Removed the blacklist and associated commands.
+- Ability to ban any user by their ID, even if they are not in the affected server. <SuggestionLink id="113" /> <SuggestionLink id="148" />
+- Display of the ban reason in the response of the [`?ban` command](./features/moderation.md#ban).
+- The [`?raidmode` command](./features/raid-mode.md) now requires the permission to kick members.
+- Changed the kick duration if the captcha is not completed (5 min). <SuggestionLink id="129" />
+- Various internal improvements.
+
+## 2.1.2 (04/17/2019) {#2-1-2}
+
+- Added the [`?userinfo` command](./features/utilities.mdx#userinfo). <SuggestionLink id="29" />
+- ~~Added the `?lockall` and `?unlockall` commands~~ (Feature removed).
+- Added the [`?kick`](./features/moderation.md#kick) and [`?ban`](./features/moderation.md#ban) commands.
+- Added [min-age to the captcha](./features/raid-mode.md#minage) (ability to set a minimum account age to access the server).
+- Option to configure automatic deletion of command invocation messages. <SuggestionLink id="26" />
+- The logs channel is automatically recreated if deleted.
+- Overhauled database connection.
+- Bug fixes and various improvements.
+
+## 2.1.1 (02/21/2019) {#2-1-1}
+
+- Removed `?settings captcha` (replaced by `?captcha`).
+- Added the ability to set a [logs channel](./features/captcha.md#logs) for the captcha.
+- Added an [autorole](./features/captcha.md#autorole) compatible with the captcha.
+- Simplified the [captcha](./features/captcha.md) (5/6 correct letters required).
+- Other minor changes.
+
+## 2.1.0 (02/16/2019) {#2-1-0}
+
+- Added captcha (`?settings captcha`). <SuggestionLink id="11" />
+- Added anti-spam security level (`?settings spamlevel`). <SuggestionLink id="25" />
+- Added the `?about` and `?invite` commands.
+- Added the [`?clear` command](./features/moderation.md#clear).
+- Various changes and bug fixes.
+
+## 2.0.1 (02/04/2019) {#2-0-1}
+
+- Rewrote the help (`?help`).
+- Fixed bugs in [`?lock`](./features/channel-lock.md#lock) and [`?unlock`](./features/channel-lock.md#unlock).
+
+## 2.0.0 (01/26/2019) {#2-0-0}
+
+- Added [anti-spam](./features/anti-spam.mdx).
+- Added [automatic raid mode](./features/raid-mode.md#config).
+- Added the logs channel.
+- Added bot configuration.
+- Added [channel locking](./features/channel-lock.md).
+- Numerous various changes.

--- a/i18n/de/docusaurus-plugin-content-docs/current/features/anti-spam.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/features/anti-spam.mdx
@@ -1,0 +1,98 @@
+---
+title: Anti-spam
+---
+
+import SeparatedBox from '@site/src/components/SeparatedBox';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+RaidProtect's Anti-spam is a powerful tool to prevent spam on your Discord server. Thanks to its automatic detection system, it handles issues on its own without requiring your intervention.
+
+## ❓ How the Anti-spam Works {#working}
+
+RaidProtect's anti-spam detects and automatically blocks suspicious behavior. It distinguishes between two types of spam.
+- **Heavy spam:** Messages containing invitation links, mass mentions, or images. This type of spam is often used during raids.
+- **Light spam:** Messages sent frequently but less intrusive.
+
+RaidProtect's anti-spam acts in two ways.
+- **Sanctions:** Automatic kicking or banning of spammers.
+- **Notifications:** Sends messages to the log channel to report blocked spam with an overview of detected actions.
+
+## 🛡️ Configuring the Anti-spam {#config}
+
+RaidProtect offers three security levels to meet your server's needs.
+- 🔴 **High:** Sanctions all spam, including heavy spam in ignored channels.
+- 🟠 **Medium:** Sanctions all spam but respects ignored channels.
+- 🟢 **Low:** Sanctions only heavy spam.
+
+![Anti-spam settings screenshot](../assets/rp-settings-anti-spam.webp)
+
+### Changing the Security Level {#level}
+
+1. Use the [`/settings` command](../setup.md#settings).
+2. Click on the “**Anti-spam**” button.
+3. Select the desired anti-spam level from the first dropdown.
+
+### Managing Ignored Roles, Users, and Channels {#ignore}
+
+You can exclude certain channels, roles, or even users from anti-spam monitoring for added flexibility. 😉
+1. Use the [`/settings` command](../setup.md#settings).
+2. Click on the “**Anti-spam**” button.
+3. Select the different options to ignore in the dropdowns:
+- Channel(s) to ignore
+- Role(s) to ignore
+- Member(s) to ignore
+
+:::info
+Channels containing “**spam**” in their name are automatically ignored. Users with administrator permissions are completely ignored.
+:::
+
+### Configure Sanctions by Trigger {#triggers}
+
+You can customize the sanctions applied depending on the type of spam detected. This allows for a response adapted to the severity of the violation.
+
+1. Use the [ `/settings` command](../setup.md#settings).
+2. Click on the “**Anti-spam**” button.
+3. Go to the “**Sanctions**” tab.
+4. For each trigger, select a specific sanction. You can modify these values using the dropdown menus:
+- **Select a trigger**: choose the type of spam to configure.
+- **Select a sanction**: choose the corresponding sanction.
+
+#### Types of Sanctions and Triggers {#sanctions}
+
+Here are the different **available sanctions** as well as the **triggers** that RaidProtect can detect, along with the **default timeout duration** if applicable:
+
+- **Warn**: Sends a warning to the member.
+- **Kick**: Removes the member from the server.
+- **Timeout**: Mutes the member for a set duration.
+- **Softban**: Bans and immediately unbans the member, deleting their messages.
+- **Ban**: Permanently bans the member.
+
+| Trigger                                | Description                                             | Timeout Duration   |
+|----------------------------------------|---------------------------------------------------------|--------------------|
+| Spam                                   | Repeated message sending                                | 1 minute           |
+| Spam with selfbot                      | Use of selfbots to spam                                 | 1 hour             |
+| Mention spam                           | Repeated mass mentions                                  | 30 minutes         |
+| Link spam                              | Mass sending of links                                   | 24 hours           |
+| Duplicate or heavy spam                | Copied messages or excessive spam                       | 24 hours           |
+
+![Screenshot of anti-spam sanctions](../assets/rp-settings-anti-spam-sanctions.webp)
+
+## 📑 Anti-spam Logs {#logs}
+
+Detailed logs are generated with all messages deleted by the anti-spam. You can simply download or expand the content.
+
+<SeparatedBox>
+<Tabs>
+  <TabItem value="animator" label="Collapsed" default>
+
+![Screenshot of anti-spam logs](../assets/rp-logs-anti-spam.webp)
+
+  </TabItem>
+  <TabItem value="moderator" label="Expanded">
+
+![Screenshot of expanded anti-spam logs](../assets/rp-logs-anti-spam-expand.webp)
+
+  </TabItem>
+</Tabs>
+</SeparatedBox>

--- a/i18n/de/docusaurus-plugin-content-docs/current/features/captcha.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/features/captcha.md
@@ -1,0 +1,57 @@
+---
+title: Captcha (Verification)
+---
+
+Prevent selfbots from accessing your Discord server and block raids with RaidProtect's captcha system.
+
+Captcha is one of RaidProtect's most popular features, though it remains entirely optional. It allows you to require each new user to complete a challenge by entering a code to verify that they are not a bot (selfbot).
+
+## ❓ How Captcha Works {#working}
+
+Captcha relies on a **@Unverified** role and a **#verification** channel. When a user joins your server:
+- The bot automatically assigns the **@Unverified** role to this user, limiting their access only to the **#verification** channel.
+- In this channel, the bot sends an image containing 6 uppercase letters. The user must transcribe the letters in the channel to prove they are human.
+- If the response is correct, the **@Unverified** role is removed, and the user gains normal access to the server. Otherwise, they are automatically kicked.
+- When captcha is enabled, RaidProtect automatically posts a message in the logs channel, indicating the account creation date of each new user.
+- RaidProtect automatically detects permission issues (channel and role) as well as the default visibility of the channel during Discord's onboarding process.
+
+:::info
+**Time Limit and Attempts:** Users have **1 to 10 minutes** to complete captcha (**5 minutes by default**) and **1 to 3 attempts** (**2 attempts by default**). If they exceed these limits, they are automatically kicked from the server.
+:::
+:::warning
+**Permission Management:** The permissions for the **@Unverified** role are automatically configured by RaidProtect. You can rename the role and the channel, but do not delete them.
+:::
+
+## 🚪 Captcha Configuration {#config}
+
+Setting up captcha is quick and easy.
+
+1. Run the [`/settings` command](../setup.md#settings).
+2. Click the "**Captcha**" button.
+3. Choose the channel where captchas will be conducted or use the "**Create one for me**" button.
+4. The **@Unverified** role is automatically created and configured.
+5. Configure the allowed number of attempts (between **1 and 3**) and the maximum resolution time (between **1 and 10 minutes**).
+
+![Captcha settings screenshot](../assets/rp-settings-captcha.webp)
+
+## ✨ Additional Features {#additional-features}
+
+To adapt to your server's needs, RaidProtect's captcha offers customizable options.
+
+### Separate Logs {#logs}
+
+If your server is popular, captcha-related logs may clutter your main logs channel. You can move them to another channel.
+
+1. Run the [`/settings` command](../setup.md#settings).
+2. Click the "**Logs**" button.
+3. Select "**Captcha**".
+4. Choose the channel where captcha logs will be stored or use the "**Create one for me**" button.
+
+### Auto Role {#autorole}
+
+If you use an automatic role (autorole) system other than RaidProtect, it may interfere with captcha. Replace your existing autorole with RaidProtect's.
+
+1. Run the [`/settings` command](../setup.md#settings).
+2. Click the "**Captcha**" button.
+3. Select "**Auto Role**".
+4. Choose the role that will be assigned to members who successfully complete captcha.

--- a/i18n/de/docusaurus-plugin-content-docs/current/features/channel-lock.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/features/channel-lock.md
@@ -1,0 +1,32 @@
+---
+title: Channel locking
+---
+
+Sometimes it is necessary to temporarily lock a channel to prevent users from sending messages. With the lock command, this becomes a breeze!
+
+## 🔒 Lock a Channel {#lock}
+
+Use the command: ```/lock```
+
+This will remove the speaking permission from the **@everyone** role in the channel, preventing all users from posting in that channel.
+
+## 🔓 Unlock a Channel {#unlock}
+
+Use the command: ```/unlock```
+
+This will add the speaking permission back to the **@everyone** role in the channel, allowing all users to post in that channel.
+
+:::warning
+For the lock command to work properly, you must ensure that no roles have explicit permission to speak in that channel. Otherwise, members with those roles will still be able to chat.
+:::
+:::info
+The `lock` and `unlock` commands are [usable by prefix](../guides/prefix.md).
+:::
+
+## ✏️ Configuring the Lock Icon {#config}
+
+By default, this feature is disabled. However, you can choose whether locked channels should be renamed with a lock emoji (🔒) added in front of their name.
+
+To enable/disable the lock icon in front of the names of locked channels:  
+1. Use the [command `/settings`](../setup.md#settings).
+2. Click on the **Lock Icon on Locked Channels** button. This button acts as a toggle; a simple click is enough to enable or disable the option.

--- a/i18n/de/docusaurus-plugin-content-docs/current/features/dm-lock.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/features/dm-lock.mdx
@@ -1,0 +1,69 @@
+---
+title: DM Lock
+---
+
+import SeparatedBox from '@site/src/components/SeparatedBox';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+The **DM Lock** feature of RaidProtect permanently closes access to server-originated direct messages (DMs), surpassing Discord’s native limitation, which only allows this block for 24 hours via the "Pause DMs" security action.
+
+## 🚦 Use cases and recommendations {#recommendations}
+
+- **Servers exposed to spam or harassment:** DM Lock is especially recommended for public or high-traffic communities where the risk of DM abuse is higher.
+- **Temporary events or sensitive periods:** During launches, major announcements, or periods of heavy activity (e.g. contests, promotions), enabling DM Lock helps prevent phishing or scam attempts.
+- **Communities with a young audience:** For servers with many minors, restricting DMs can enhance safety and help prevent inappropriate behavior.
+- **Continuous protection:** Thanks to automation, there’s no vulnerability window from forgetting to renew the block manually.
+
+## ❓ How DM Lock works {#working}
+
+The RaidProtect bot regularly checks the server’s DM blocking setting and, if needed, automatically re-enables it to prevent any vulnerability window between manual renewals. This task runs transparently for server admins and members.
+
+:::info
+It remains possible to send and receive messages with:
+- friends
+- bots
+- staff
+:::
+:::warning
+Discord’s community features are essential for DM Lock to function properly. [Follow our guide to check if Community is enabled on your server.](../guides/community.md)
+:::
+
+## 🚩 Configuring DM Lock {#config}
+
+1. Run the [ `/settings` command](../setup.md#settings).
+2. Click on the “**DM Lock**” button.
+3. Enable or disable automatic closing of direct messages.
+
+![DM Lock settings screenshot](../assets/rp-settings-dm-lock.webp)
+
+## ℹ️ Command /dmlock-info {#info}
+
+The `/dmlock-info` command informs members about the current **DM Lock** status on the server. It displays a clear message indicating whether the restriction is **enabled** or **disabled**, along with an educational explanation of its purpose.
+
+**Goal:**
+- Explain why DMs are limited (to combat spam, scams, phishing).
+- Reduce confusion and repeated questions from new members.
+- Remind members of the conditions for continuing DM conversations (friends, staff, bots, existing contacts).
+
+**Example Display**
+<SeparatedBox>
+<Tabs>
+  <TabItem value="enable" label="Enabled" default>
+
+![Screenshot of the dmlock-info command enabled](../assets/rp-dm-lock-info-enable.webp)
+
+  </TabItem>
+  <TabItem value="disable" label="Disabled">
+
+![Screenshot of the dmlock-info command disabled](../assets/rp-dm-lock-info-disable.webp)
+
+  </TabItem>
+</Tabs>
+</SeparatedBox>
+
+### ⚙️ Best Practices
+
+- Encourage active members to use `/dmlock-info` to answer new members’ questions.
+- Display it regularly or pin it in your welcome channels.
+- Combine it with your rules or announcements to reinforce the server’s anti-spam policy.

--- a/i18n/de/docusaurus-plugin-content-docs/current/features/index.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/features/index.mdx
@@ -1,0 +1,9 @@
+---
+title: Features
+---
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```

--- a/i18n/de/docusaurus-plugin-content-docs/current/features/moderation.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/features/moderation.md
@@ -1,0 +1,41 @@
+---
+title: Moderation
+---
+
+To facilitate the work of your moderators, RaidProtect integrates very useful moderation commands that allow you to interact directly with Discord's native features, such as **banning** and **kicking** users.
+
+In addition to these actions, RaidProtect sends direct messages to the sanctioned user to explain the reason for their sanction, and this is also recorded in the server logs for your reference.
+
+:::info
+Moderation commands are [usable by prefix](../guides/prefix.md).
+:::
+
+## 🔨 Ban a User {#ban}
+
+Use the command: ```/ban [@user] [reason]```
+
+Replace `[@user]` with the desired mention or ID and `[reason]` with the reason for the sanction.
+
+:::tip
+You can ban a user using their [Discord ID](https://dfr.gg/wiki/interface/mode-developpeur), even if they are not currently online or present on your server.
+:::
+
+## 👢 Kick a User {#kick}
+
+Use the command: ```/kick [@user] [reason]```
+
+Replace `[@user]` with the desired mention or ID and `[reason]` with the reason for the sanction.
+
+## ⏳ Timeout a User {#timeout}
+
+Use the command: ```/timeout [@user] [duration] [reason]```
+
+Replace `[@user]` with the desired mention or ID, `[duration]` with the timeout length, up to a maximum of 28 days (e.g. `10m`, `1h`, `1d`), and `[reason]` with the reason for the sanction.
+
+## 🧹 Clear a Group of Messages {#clear}
+
+The command `/clear` allows you to quickly delete a certain number of messages in a text channel. You can specify a user to delete only their messages.
+
+Use the command: ```/clear [number] (@user)```
+
+Replace `[number]` with the number of messages you wish to delete (maximum 100). Add `(@user)` using the mention or ID to target only their messages in the channel.

--- a/i18n/de/docusaurus-plugin-content-docs/current/features/raid-mode.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/features/raid-mode.md
@@ -1,0 +1,63 @@
+---
+title: Anti-raid
+---
+
+## Raid Mode
+
+Raid mode is an emergency feature designed to instantly block all new users trying to join your server, surpassing Discord’s native limitation which only allows this block for 24 hours via the "Pause Invites" security action.
+
+### ❓ How Raid Mode Works {#working}
+
+RaidProtect automatically enables raid mode if a large number of users join your server in a short time. By default, raid mode activates if more than 10 users join your server in less than 10 seconds. When raid mode is enabled, no users can join the server. They are blocked at the invite level.
+
+:::warning
+Discord’s Community features are essential for Raid Mode to work properly. [Follow our guide to ensure Community is enabled on your server.](../guides/community.md)
+:::
+
+#### Enabling {#enable}
+
+- To manually enable this mode, a user with kick permissions must run the `/raidmode` command.
+- A message will automatically be posted in the log channel to signal activation.
+
+#### Disabling {#disable}
+
+Raid mode does not disable itself automatically. Remember to turn it off with the same command once the threat has passed. 😇
+
+:::info
+The `raidmode` command is also [available with prefix](../guides/prefix.md).
+:::
+
+### 🚨 Auto Raid Mode Configuration {#config}
+
+If your server often gets many new members at once, it’s wise to adjust this threshold to avoid false positives.
+
+![Screenshot of auto raid mode settings](../assets/rp-settings-raid-mode.webp)
+
+:::note
+We recommend setting a value between 10 and 20 members in 10 seconds for optimal system performance.
+:::
+
+1. Run the [ `/settings` command](../setup.md#settings).
+2. Click the “**Auto RaidMode**” button.
+3. Select the number of members allowed to join within 10 seconds.
+
+You can leave it at the default value (10) or adjust it to your desired value by clicking the “**Custom Value**” button.
+
+:::warning
+If raid mode is automatically triggered, don’t forget to disable it once the threat has passed. Remember, it does not turn off on its own. 😖
+:::
+
+
+## Minimum Account Age {#minage}
+
+To improve security, you can require a minimum Discord account age for new members.
+
+1. Run the [ `/settings` command](../setup.md#settings).
+2. Click the “**Minimum Age**” button.
+3. Select the desired value from the dropdown menu or choose a custom value in date format (m/h/d/y).
+
+### 🎂 Minimum Account Age Bypass {#bypass-minage}
+
+Use the command: ```/bypass minage [user]```
+
+Replace `[user]` with the desired ID; they will have 10 minutes to join the server without being kicked for not meeting the age requirement.

--- a/i18n/de/docusaurus-plugin-content-docs/current/features/reports.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/features/reports.md
@@ -1,0 +1,61 @@
+---
+title: Reports
+---
+
+The RaidProtect reporting system allows your community to quickly report any problematic content or suspicious users. It operates in two different ways and can be configured to optimize the reporting management process.
+
+## ❓ How Reporting Works {#working}
+Members can report content through 3 main methods.
+
+1. **Right-click on a message**  
+A member can right-click on a message they believe violates the rules, select **`Applications`**, and then click on **`Report Message`**. A popup will appear, allowing the user to add an explanation.
+
+2. **Right-click on a profile**  
+Similarly, a member can right-click on a profile they find problematic, choose **`Applications`**, and then click on **`Report Member`**. A popup will then open to allow the user to provide additional details about the situation.
+
+3. **Slash Command**  
+Members can also report a message or user via the **`/report`** command in any server channel.
+
+Use the command: ```/report [@user] [reason]```
+
+Replace `[@user]` with the desired user and `[reason]` with the reason for the infraction.
+
+## 🚩 Configuring Reports {#config}
+
+Before the reporting system is fully operational, it is imperative to configure a **report channel** where all reports will be sent. You need to set up a log or notification channel to receive alerts regarding reports.
+
+[Report settings screenshot](../assets/rp-settings-reports.webp)
+
+### Setting Up the Channel {#config-channel}
+
+1. Use the [command `/settings`](../setup.md#settings).
+2. Select the **Reports** button.
+3. Click on the **Channel** button.
+4. Choose the desired channel (_e.g. #reports_).  
+If you do not have a suitable channel, you can opt to create one automatically using the **Create one for me** button.
+
+### Configuring the Notification Role {#config-role}
+
+1. Use the [command `/settings`](../setup.md#settings).
+2. Select the **Reports** button.
+3. Click on the **Role** button.
+4. Choose the desired role (_e.g. @Moderator or @Report Ping_).  
+If you do not have a suitable role, you can opt to create one automatically with the **Create one for me** button.
+
+:::warning
+The channel should be restricted to moderators and administrators to ensure proper management of reports.
+:::
+
+## Managing Reports {#manage}
+
+As a community moderator, you can choose to accept or reject a report.
+
+- **✅ Accept a report:** If the report is valid, click the “Accept” button under the alert. This button does not trigger any specific action but indicates to other moderators that you consider this report to be handled, fostering coordination and organization.
+
+- **👁️ View Context:** To view the reported message and see the context, click “View Message” under the alert.
+
+- **❌ Reject a report:** If the report is not legitimate, click the “Reject” button under the alert. Similar to the “Accept” button, no specific action is associated with this button; it merely informs other moderators of your decision.
+
+:::note
+Ensure that your moderators are well-trained in using this feature and encourage your active members to use it responsibly!
+:::

--- a/i18n/de/docusaurus-plugin-content-docs/current/features/tag-role.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/features/tag-role.md
@@ -1,0 +1,28 @@
+---
+title: Tag Role
+---
+
+The Tag Role automatically assigns a role to members who add [your server’s tag](https://support.discord.com/hc/en-us/articles/31444248479639-Server-Tags) to their Discord profile. By assigning a role to these members, you acknowledge their commitment and encourage them to actively represent your server. It’s a simple yet effective way to strengthen collective identity while rewarding your community’s most loyal ambassadors.
+
+## ❓ How the Tag Role Works {#working}
+
+It’s simple. As soon as a member adds the server’s tag to their Discord profile, RaidProtect automatically assigns them a specific role.  
+If the member removes the tag, the role is removed.
+
+:::info
+If the Tag is not enabled or your server doesn’t yet have the feature, the Tag Role will have no effect.
+:::
+
+## 🎖️ Configuring the Tag Role {#config}
+
+Configuration takes just a few clicks:  
+1. Use the [command `/settings`](../setup.md#settings).  
+2. Click the “**Tag Role**” button.  
+3. Select an existing role via the selector or click “**Create one for me**”.  
+4. You can deselect the role at any time by clicking on the “**Reset**” button.
+
+[Tag Role settings screenshot](../assets/rp-settings-tag-role.webp)
+
+:::tip
+Members will receive the role the next time they update their profile (Username, Avatar, Banner, Roles, Tag…). You can [contact support](https://raidprotect.bot/discord) to request a full role sync if you have many members who currently have or previously had the Tag.
+:::

--- a/i18n/de/docusaurus-plugin-content-docs/current/features/utilities.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/features/utilities.mdx
@@ -1,0 +1,117 @@
+---
+title: Utilities
+---
+
+import SeparatedBox from '@site/src/components/SeparatedBox';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import Icon from "@site/src/components/Icon";
+
+Extra features to simplify the management of your server. 🔧
+
+In addition to core features like the captcha system and anti-raid protection, RaidProtect offers several secondary tools that can make managing your server even smoother.
+
+:::info
+Utility commands are [usable with a prefix](../guides/prefix.md).
+:::
+
+## 👤 User Information {#userinfo}
+
+The `/userinfo` command lets you get detailed information about a user.
+
+Use the command: ```/userinfo [@user]```
+
+Replace `[@user]` with the desired mention or ID.
+
+### 📋 Displayed Information {#displayed-userinfo}
+
+- **Discord account creation date**
+- User's **profile picture**
+- **Profile banner**
+- **Profile badges**
+  - The Nitro, Booster, Quest, and Originally Name badges are not displayed.
+
+
+### 🎭 Information about a server member {#displayed-memberinfo}
+
+If the target is a server member, additional info includes:
+
+- **Date joined the server**
+- **Server nickname**
+- **Number of roles** and **list of the first 6 roles**
+- **Permission category** (visible only to moderators):
+
+<SeparatedBox>
+<Tabs>
+  <TabItem value="animator" label="Animator" default>
+
+    The **Animator** category is shown if the member has **at least one** of the following permissions:
+
+    - `MANAGE_EXPRESSIONS`
+    - `CREATE_GUILD_EXPRESSIONS`
+    - `MANAGE_EVENTS`
+
+  </TabItem>
+  <TabItem value="moderator" label="Moderator">
+
+    The **Moderator** category is shown if the member has **at least one** of the following permissions:
+
+    - `KICK_MEMBERS`
+    - `BAN_MEMBERS`
+    - `MODERATE_MEMBERS`
+    - `MANAGE_MESSAGES`
+    - `MUTE_MEMBERS`
+    - `DEAFEN_MEMBERS`
+    - `MOVE_MEMBERS`
+    - `MANAGE_THREADS`
+
+  </TabItem>
+  <TabItem value="manager" label="Manager">
+
+    The **Manager** category is shown if the member has **at least one** of the following permissions:
+
+    - `MANAGE_GUILD`
+    - `MANAGE_ROLES`
+    - `MANAGE_CHANNELS`
+    - `VIEW_AUDIT_LOG`
+    - `MANAGE_WEBHOOKS`
+    - `MANAGE_SERVER_EXPRESSIONS`
+
+  </TabItem>
+  <TabItem value="admin" label="Administrator">
+
+    The **Administrator** category is shown in **two possible cases**:
+
+    1️⃣ Has the permission:
+    - `ADMINISTRATOR`
+
+    2️⃣ Has **all three** of the following permissions at the same time:
+    - `MANAGE_GUILD`
+    - `MANAGE_ROLES`
+    - `MANAGE_CHANNELS`
+
+  </TabItem>
+  <TabItem value="owner" label="Owner">
+
+    **Condition**: The member is the **server owner**.
+
+  </TabItem>
+</Tabs>
+</SeparatedBox>
+
+- **Member flags** (visible only to moderators)
+
+Certain special indicators (flags) can be displayed for a member:
+
+| **Flag**                                 | **Displayed Emoji**                                                                                                    | **Explanation**                                                   |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `DID_REJOIN`                             | <Icon src="/img/icons/MemberDidRejoin.svg" alt="icon MemberDidRejoin" title=":MemberDidRejoin:"/>                      | The user left and rejoined the server.                            |
+| `IS_GUEST`                               | <Icon src="/img/icons/MemberIsGuest.svg" alt="icon MemberIsGuest" title=":MemberIsGuest:"/>                            | Guest member (temporary invite or guest access).                  |
+| `COMPLETED_ONBOARDING`                   | <Icon src="/img/icons/OnboardingCompleted.svg" alt="icon OnboardingCompleted" title=":OnboardingCompleted:"/>          | Completed the server onboarding process.                          |
+| `STARTED_ONBOARDING`                     | <Icon src="/img/icons/OnboardingStarted.svg" alt="icon OnboardingStarted" title=":OnboardingStarted:"/>                | Started the onboarding process.                                   |
+| `COMPLETED_SERVER_GUIDE`                 | <Icon src="/img/icons/ServerGuideCompleted.svg" alt="icon ServerGuideCompleted" title=":ServerGuideCompleted:"/>       | Completed the server guide if enabled.                            |
+| `STARTED_SERVER_GUIDE`                   | <Icon src="/img/icons/ServerGuideStarted.svg" alt="icon ServerGuideStarted" title=":ServerGuideStarted:"/>             | Started the server guide.                                         |
+| `AUTOMOD_QUARANTINED_NAME`               | <Icon src="/img/icons/MemberQuarantined.svg" alt="icon MemberQuarantined" title=":MemberQuarantined:"/>                | Quarantined by automoderation for the username.                   |
+| `AUTOMOD_QUARANTINED_GUILD_TAG`          | <Icon src="/img/icons/MemberQuarantined.svg" alt="icon MemberQuarantined" title=":MemberQuarantined:"/>                | Quarantined by automoderation for the tag or nickname.            |
+| `BYPASSES_VERIFICATION`                  | <Icon src="/img/icons/BypassVerification.svg" alt="icon BypassVerification" title=":BypassVerification:"/>             | User can bypass server verification.                              |
+| `SPAMMER`                                | <Icon src="/img/icons/UnusualAccountActivity.svg" alt="icon UnusualAccountActivity" title=":UnusualAccountActivity:"/> | Account marked as spammer or unusual activity detected.           |

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/community.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/community.md
@@ -1,0 +1,37 @@
+---
+title: Enable Community
+---
+
+Enabling the Community feature unlocks several advanced security settings essential for the proper functioning of some RaidProtect features like **DM Lock** or **Raid Mode**.
+
+## 🚦 Requirements {#requirement}
+
+- You must be an administrator of the Discord server.
+
+## 🚩 Enable Community Features {#steps}
+
+1. **Open your server settings**
+   - Click on the server name at the top left > “Server Settings”.
+
+2. **Go to the “Community” section**
+   - In the sidebar, navigate to the **Enable Community** tab and click **Get Started**.
+
+:::note
+If Community is already enabled on your server, the section will be called **Community Overview**.
+:::
+
+3. **Follow the setup wizard**
+   - Enable email verification for all members.
+   - Enable the explicit content filter.
+   - Set up a rules channel and an updates channel.
+   - Accept the Community Server guidelines.
+
+4. **Complete the setup**
+   - Click “Finish Setup”. The “Community” badge will appear on your server once activation is complete.
+
+![Discord Community activation screenshot](../assets/rp-enable-community.webp)
+
+## 💡 Use DM Lock & Raid Mode modules after activation {#use}
+
+- Run the [`/settings`](../setup.md#settings) command to open the RaidProtect configuration menu.
+- Enable or disable the desired modules (DM Lock, Raid Mode, etc.) from the interactive menu.

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/id.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/id.mdx
@@ -1,0 +1,98 @@
+---
+title: Using IDs
+---
+
+import SeparatedBox from '@site/src/components/SeparatedBox';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Discord IDs are unique numbers that precisely identify each user, channel, server, or message on Discord. They are a reliable and permanent way to identify elements on the platform.
+
+:::note Relevance for Moderation
+Using Discord IDs is especially useful for moderation actions because it allows you to:
+- **Sanction an absent user**: Ban someone who has left the server
+- **Avoid mistakes**: Precisely identify the right person even with similar usernames
+- **Keep track**: IDs never change, unlike usernames
+- **Conflict resolution**: Clear identification in case of special characters
+:::
+
+## Enabling Developer Mode
+
+You need to enable Developer Mode to use Discord IDs.
+
+<SeparatedBox>
+<Tabs>
+  <TabItem value="desktop" label="On Discord Desktop/Web" default>
+
+    1. **Open User Settings**
+    - Click the gear icon ⚙️ at the bottom left of the interface
+
+    2. **Access Advanced Settings**
+    - In the sidebar, go to the **Advanced** tab
+
+    3. **Enable Developer Mode**
+    - Turn on the **"Developer Mode"** option by clicking the toggle button
+    - The button should turn blue once enabled
+
+  </TabItem>
+  <TabItem value="mobile" label="On Discord Mobile">
+
+    1. **Open User Settings**
+    - Tap your avatar at the bottom right
+    - Tap the gear icon ⚙️ at the top right of the interface
+
+    2. **Access Advanced Settings**
+    - Scroll down and tap **"Advanced"**
+
+    3. **Enable Developer Mode**
+    - Turn on the **"Developer Mode"** option
+
+  </TabItem>
+</Tabs>
+</SeparatedBox>
+
+## Copying an ID
+
+Once Developer Mode is enabled, you can copy the ID of any element:
+
+<SeparatedBox>
+<Tabs>
+  <TabItem value="user" label="User ID" default>
+
+    - **Right-click** on the avatar or username
+    - Select **"Copy User ID"**
+
+  </TabItem>
+  <TabItem value="channel" label="Channel ID">
+
+    - **Right-click** on the channel name in the channel list
+    - Select **"Copy Channel ID"**
+
+  </TabItem>
+  <TabItem value="server" label="Server ID">
+
+    - **Right-click** on the server name at the top left
+    - Select **"Copy Server ID"**
+
+  </TabItem>
+  <TabItem value="message" label="Message ID">
+
+    - **Right-click** on a message
+    - Select **"Copy Message ID"**
+
+  </TabItem>
+</Tabs>
+</SeparatedBox>
+
+## Using with RaidProtect
+
+IDs can be used in RaidProtect commands instead of mentions:
+
+- [`/ban user:123456789012345678 reason:Server rules violation`](../features/moderation#ban)
+- [`/clear amount:100 user:123456789012345678`](../features/moderation#clear)
+- [`/userinfo user:123456789012345678`](../features/utilities#userinfo)
+- [`/bypass mining user:123456789012345678`](../features/raid-mode#minage)
+
+:::info
+You can ban a user using their Discord ID, even if they are not online or present in your server.
+:::

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/index.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/index.mdx
@@ -1,0 +1,9 @@
+---
+title: Guides
+---
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/malfunctions.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/malfunctions.md
@@ -1,0 +1,61 @@
+---
+title: Malfunctions
+---
+
+Having an issue with RaidProtect? The solution is likely here.
+
+Sometimes things don't work as expected. Here are the **most common problems** you may encounter, along with how to solve them. 🤗 
+
+If this page does not answer a problem you're experiencing, [**feel free to contact our support**](https://raidprotect.bot/discord) who will be happy to help you!
+
+## The bot shows an error when I run a command {#commands}
+
+If the command does not execute successfully, **RaidProtect may display an error** instead of the expected result. In most cases, there will be an indication in the message, but it may be a more generic message. Here’s how to resolve this issue in most cases. 🧐 
+
+- **Do what is indicated.** Some errors clearly explain the problem. If the bot asks you to do something, please do it.
+
+- **Check the command parameters.** The command might simply be misspelled; check the help on how to use it. Remember that brackets ([]) are not to be included.
+
+- **Check the bot's permissions.** The bot must have **Administrator** permission and be at the administrator level in the role hierarchy.
+
+- **Retry the command.** Sometimes the issue resolves itself for unknown reasons.
+
+If you continue to receive an error despite following these tips, [contact our support](https://raidprotect.bot/discord) so we can assist you. 🤝 
+
+## The bot's log channel didn't create itself {#logs}
+
+To notify you of the actions it takes, RaidProtect needs a log channel. This channel is created automatically when the bot first joins, but sometimes no channel is created. Here’s how to remedy this issue. ⚙️ 
+
+- **Ensure the bot is an Administrator.** For the bot to function properly, it must be given Administrator permission. If this is not done, go to the role settings and grant this permission to the RaidProtect role. You then just need to manually initialize the bot for everything to work (see below)!
+
+- **Check that the bot is properly initialized.** This is usually done automatically, but you can force this initialization with the [command `/setup`](../setup.md#install). The log channel should be created automatically.
+
+- **Manually set a channel.** If nothing works, don’t panic; you can manually choose the channel the bot will use for logs! Once a dedicated channel is created, execute the [command /settings](../setup.md#settings) and then select Logs.
+
+## A user spammed, but the bot did not sanction them {#anti-spam}
+
+The [anti-spam](../features/anti-spam.mdx) feature is one of RaidProtect's main functionalities, and it can be frustrating if it’s not working. But rest assured, most of the time it’s nothing serious. 😇 
+
+- **If the anti-spam asks to stop the spam but does not sanction,** this is likely due to a lack of permissions. Remember, the bot must have Administrator permission and must be at the administrator level in the role hierarchy.
+
+- **Check the anti-spam configuration.** It’s quite simple, but some forget that they have ignored a channel.
+
+- **Check the spammer's permissions.** Administrators are ignored, so if you’re testing the anti-spam on your own server, it may not detect you.
+
+- **Is the spam long enough?** The bot generally only detects spam if it’s more than 5 messages. Don’t be too hasty.
+
+If spam is still not detected, [contact us on our support server](https://raidprotect.bot/discord) with a **screenshot of the issue**.
+
+## Users have access to the server without completing the captcha {#captcha}
+
+This problem is relatively common, but it depends on **your server configuration**. Let’s see how to fix it. 🏥 
+
+- **Do you have an auto role?** If you have set up a bot (other than RaidProtect) to give a role to newcomers on your server, this may interfere with the captcha. Replace it with the [RaidProtect autorole](../features/captcha.md#autorole). 
+
+- **Have you activated the captcha?** This is a completely optional feature that requires you to execute a command to enable it. Check the [dedicated captcha documentation page](../features/captcha.md#config) for more information.
+
+## Users can still talk when I lock a channel {#lock}
+
+The lock command seems magical, but it has its weaknesses. As [noted in this documentation](../features/channel-lock.md#lock), the command **only affects the @everyone role**. This means that if there is a role in the channel you want to lock that explicitly has permission to speak, they will still be able to do so. A picture is worth a thousand words, so here’s what that looks like in practice. 🔍 
+
+[Screenshot of channel lock configuration](../assets/lock-channel-messages-raidprotect.png)

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/onboarding.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/onboarding.md
@@ -1,0 +1,52 @@
+---
+title: Onboarding Process and Captcha
+---
+
+If the `#verification` channel is not visible by default for new members, this can prevent the Captcha system from working properly. Here’s how to fix this issue step by step.
+
+![Captcha alert screenshot](../assets/rp-settings-captcha-alert.webp)
+
+## 1️⃣ Check the channel permissions {#permissions}
+
+1. Open the `#verification` channel settings (right-click > **Edit Channel**).
+2. In the **Permissions** tab:
+   - Make sure `@everyone` **does not** have permission to view the channel.
+   - Ensure the `@Unverified` role **has** permission to **view the channel**, **read message history**, and **send messages**.
+
+![Screenshot channel permissions check](../assets/rp-verification-channel-permissions.webp)
+
+## 2️⃣ Check the Welcome category {#default-category}
+
+1. Go to **Server Settings** > **Onboarding**.
+2. In the **Default Channels** section, verify that the category containing `#verification` is checked as visible for new members.
+3. If needed, move `#verification` into a checked category.
+4. Save the changes.
+
+![Screenshot welcome category check](../assets/rp-welcome-category.webp)
+
+## 3️⃣ Refresh the configuration in RaidProtect {#refresh-config}
+
+1. Use the [`/settings`](../setup.md#settings) command and go to the **Captcha** tab.
+2. Click **Refresh** to force the configuration update.
+3. If the channel is now visible, the Captcha system will work correctly.
+
+## 4️⃣ Test with a test account {#test-account}
+
+To confirm everything is set up properly:
+
+1. Join the server with another Discord account.
+2. Check that the `#verification` channel is visible on arrival.
+3. Enter the Captcha code sent by RaidProtect.
+4. Once verified, the account should have access to the other channels.
+
+## 🛠️ Common issues and solutions {#common-issues}
+
+| Issue | Solution |
+|-------|----------|
+| 🔴 The `#verification` channel remains invisible | Check that it is in a **checked category** in Discord’s Welcome settings. |
+| 🚫 The `@Unverified` role cannot write | Grant it **send messages** permission in `#verification`. |
+| ❌ Captcha doesn’t work after changes | Click **“Refresh”** in `/settings > Captcha`. |
+
+---
+
+✅ By following these steps, your verification system will be fully operational to safely welcome members and effectively block bots or raids.

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/prefix.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/prefix.md
@@ -1,0 +1,32 @@
+---
+title: Using a prefix
+---
+
+## Disabled Prefix (Default) {#disabled}
+
+By default, RaidProtect uses only Slash commands (`/`) to interact with the bot. This ensures intuitive and consistent usage with Discord standards.
+
+## Activated Prefix (Optional) {#activated}
+
+If you prefer to use certain commands with a custom prefix, you can enable this option. The default prefix when activated is `?`, but it can be modified to suit your needs. Once activated, these commands can be used with the configured prefix: 
+- [`?raidmode`](../features/raid-mode.md)
+- [`?ban`](../features/moderation.md#ban)
+- [`?kick`](../features/moderation.md#kick)
+- [`?lock`](../features/channel-lock.md#lock)
+- [`?unlock`](../features/channel-lock.md#unlock)
+- [`?userinfo` | `?ui`](../features/utilities#userinfo)
+- [`?clear`](../features/moderation#clear)
+
+## 💬 How to Enable or Disable the Prefix {#config}
+
+1. Open the configuration menu by typing [`/settings`](../setup.md#settings).
+2. Access the "**Prefix**" option for commands.
+3. Enable or disable the prefix according to your preferences.
+If enabled, customize the prefix by entering the desired character or string.
+
+![Prefix settings screenshot](../assets/rp-settings-prefix.webp)
+
+:::note
+Slash commands (`/`) remain available even if the prefix is activated.
+It is recommended to avoid prefixes already used by other bots to prevent command conflicts.
+:::

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/report-violation-to-discord.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/report-violation-to-discord.md
@@ -1,0 +1,35 @@
+---
+title: Report a violation to Discord
+---
+
+Have you encountered a malicious user on Discord? Report them so that they can be sanctioned.
+
+On Discord, some users may not have good intentions. If they display behavior that is particularly harmful to the community, it is advisable to **report it to Discord's Trust & Safety team**. If the violation is found to be valid, the user may face sanctions ranging from a warning to account deletion. 😖 
+
+## 🧐 What Types of Violations to Report? {#types-of-violations}
+
+Of course, not all types of violations are subject to account deletion. Punishable behaviors are described in **Discord's [Community Guidelines](https://discord.com/guidelines)** (as well as in the [Terms of Service](https://discord.com/terms), which is more legal jargon than clear instructions). The list of report types on the reporting page is a great summary for those hesitant to read extensively.
+
+In general, **harmful behaviors to the community** (spam, promotion of illegal content, etc.) or **serious harm to a user** (doxxing, harassment) should be reported.
+
+For less extreme behaviors, **prefer banning** (on a server) or [blocking](https://support.discordapp.com/hc/en-us/articles/217916488-Blocking-and-Privacy-Settings) (throughout Discord). If you are not a moderator on the server where the actions are happening, feel free to report it to the moderation team, who must take action.
+
+## 🕵️ Collecting Evidence {#recover-evidences}
+
+To make a report, you need to provide evidence. First, note that **screenshots are not useful**; they can be easily falsified. You will need at least one (or preferably several) message links.
+
+**These links are very easy to obtain**. On a message corresponding to the violation you wish to report, right-click > Copy Message Link (on desktop) or Long press > Share > Copy to Clipboard (on mobile).
+
+## 📪 Reporting the Violation to the _Trust & Safety_ Team {#report-to-tns}
+
+Filing a report is very easy and takes only a few minutes. First, go to the **dedicated form** by following the link **https://dis.gd/report**.
+
+[Screenshot of Discord report](../assets/discord-report.png)
+
+Depending on the type of report selected, **different information will be requested**. Enter the link to the message obtained in the previous step in the appropriate field (and possibly the others in the description). Don’t hesitate to be **as thorough as possible** and remember the basic rules of politeness. 😇 
+
+### 📨 Discord's Response {#discord-response}
+
+A few days after your report—generally within a week—you should receive **a response via email** from Discord. Note that you will not be able to know the sanctions taken (or not) against the reported user. 😒
+
+[Screenshot of Discord response](../assets/discord-reply.png)

--- a/i18n/de/docusaurus-plugin-content-docs/current/language.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/language.md
@@ -1,0 +1,32 @@
+---
+title: Language
+---
+
+RaidProtect allows you to choose the language used by the bot to best suit your Discord community.
+
+:::note
+If your server is set as a community server (Discord setting), RaidProtect will by default use the language configured in the server's **community settings**.
+:::
+
+**Public Messages:** The configured language only affects public messages sent by RaidProtect in your server (logs, captcha messages, reports, etc.).
+
+**Ephemeral Messages:** These private or temporary messages remain displayed in the language of the user interacting with the bot.
+
+## 🌐 List of Supported Languages {#supported}
+
+- **French**
+- **English**
+
+## ⚙️ Changing the Bot's Language {#change}
+
+- Use the [`/settings` command](./setup.md#settings).
+- Select the “**Language**” button.
+- Choose the desired language.
+
+![Screenshot of language settings](./assets/rp-settings-language.webp)
+
+Once the language is selected, the bot will automatically adapt all its messages, notifications, and commands to the chosen language for your server.
+
+:::info
+RaidProtect's language support is constantly evolving! [Suggest](https://suggestions.raidprotect.bot) languages you'd like to see on the bot or [vote](https://suggestions.raidprotect.bot) for proposed languages to have them added.
+:::

--- a/i18n/de/docusaurus-plugin-content-docs/current/readme.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/readme.mdx
@@ -1,0 +1,50 @@
+---
+title: Lies mich
+slug: /
+---
+
+import DocCard from '@theme/DocCard';
+
+Diese Dokumentation soll erklären, wie RaidProtect funktioniert. Senden Sie uns gerne Ihr Feedback, damit wir sie verbessern können.
+Vergiss nicht, unserem [Discord-Server](https://raidprotect.bot/discord) beizutreten, um über die neuesten Neuigkeiten des Projekts informiert zu bleiben. Du kannst dort auch unser Support‑Team erreichen, das deine Fragen zur Verwendung des Bots beantwortet. 😄
+
+## 🚀 Erste Schritte mit RaidProtect {#start}
+
+Um RaidProtect zu verwenden, lade ihn einfach mit folgendem Link auf deinen Server ein.
+
+<DocCard item={{ type: 'link', href: 'https://raidprotect.bot/invite', label: 'RaidProtect einladen' }} />
+<br />
+
+:::danger
+Warnung, **Kopien des Bots** mit dem Namen RaidProtect sind im Umlauf, lade ihn nur über unsere offizielle Website ein.
+:::
+
+### Voraussetzungen {#requirement}
+
+Um das ordnungsgemäße Funktionieren von RaidProtect sicherzustellen:
+1. **Erteile RaidProtect die Administrator‑Berechtigung**. Dadurch kann der Bot automatisch alle deine Kanäle moderieren.
+2. **Platziere seine Rolle auf derselben Ebene wie deine Server‑Administratoren**. Das Berechtigungssystem erlaubt RaidProtect nicht, Nutzer mit einer höheren Rolle zu sanktionieren.
+
+### Installation {#install}
+
+Sobald RaidProtect zu deinem Server hinzugefügt wurde, führe den Befehl [`/setup`](./setup.md#install) aus.
+
+<DocCard item={{ type: 'link', href: '/beta/setup', docId: 'setup', label: 'Geführte Installation' }} />
+<br />
+
+:::note
+Für die weniger Abenteuerlustigen (oder die Ungeduldigen) kannst du einfach die Anweisungen des Befehls [`/setup`](./setup.md#advanced) lesen, der die wichtigsten Informationen jeder Funktion zusammenfasst.
+:::
+
+### Verwendung {#use}
+
+Sieh dir die verschiedenen Abschnitte dieser Dokumentation an, um alle Funktionen von RaidProtect zu entdecken.
+
+<DocCard item={{ type: 'link', href: '/beta/language', docId: 'language', label: 'Verfügbare Sprachen' }} />
+<br />
+<DocCard item={{ type: 'category', href: '/beta/features', label: 'Funktionen', description: 'Dokumentation für jede unserer Funktionen.' }} />
+<br />
+<DocCard item={{ type: 'category', href: '/beta/guides', label: 'Unsere Anleitungen', description: 'Anleitungen, die dir bestmöglich helfen.' }} />
+<br />
+<DocCard item={{ type: 'category', href: '/beta/useful-links', label: 'Nützliche Links', description: 'Verschiedene nützliche Links zu RaidProtect.' }} />
+<br />

--- a/i18n/de/docusaurus-plugin-content-docs/current/setup.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/setup.md
@@ -1,0 +1,58 @@
+---
+title: Installation
+---
+
+RaidProtect simplifies server management with two powerful tools: the [`/setup`](#install) command for a step-by-step guided setup and the [`/settings`](#settings) command to adjust your settings at any time through a centralized menu. This installation guide explains how to use them effectively.
+
+## Guided Installation {#install}
+
+The `/setup` command is designed to help you configure RaidProtect quickly or through a detailed approach, depending on your needs. It offers two configuration modes: [recommended](#recommended) or [advanced](#advanced).
+
+### 🔧 Recommended Configuration {#recommended}
+
+Allows you to enable or disable core features at a glance using an interactive selection menu.
+
+1. Use the `/setup` command.
+2. Select the “**Recommended Configuration**” button.
+3. Enable or disable the desired features using the selection menu.
+
+The bot will then send you a summary of the activated features and the changes it will make to the server.
+
+![Recommended configuration screenshot](./assets/rp-setup.webp)
+
+<!--
+### 🛠️ Advanced Configuration {#advanced}
+
+If you want to configure the bot more thoroughly, opt for the advanced configuration. The bot guides you step by step with clear explanations.
+
+1. Use the `/setup` command.
+2. Select the “**Advanced Configuration**” button.
+3. Each step introduces a feature, its purpose, and a recommended minimum configuration.
+4. Use the “**Previous**” and “**Next**” buttons to move forward or go back.
+
+At the end, a summary of the settings is displayed to confirm your choices.
+-->
+## Modifying the Configuration {#settings}
+
+The `/settings` command is the go-to command for managing your settings after installation. It allows you to view, adjust, or customize RaidProtect's features at any time, in a simple and fast way.
+
+### 🔍 Settings Menu {#menu}
+
+1. Type `/settings` in a channel where the bot is active.
+2. Easily navigate between different sections to find the settings you want to modify.
+3. Adjust the options: Each category presents a list of customizable options in the form of buttons or dropdown menus.
+
+![Settings screenshot](./assets/rp-settings.webp)
+
+### 🔄 Resetting a Setting {#reset}
+
+1. Navigate to the desired setting.
+2. Click on “**Reset**”.
+
+![Reset button screenshot](./assets/rp-button-reset.webp)
+
+The bot will confirm the reset before applying the changes.
+
+:::info Configuration Issue?
+If you encounter a problem, check the [Malfunctions](./guides/malfunctions) section or join our [support server](https://raidprotect.bot/discord) for assistance.
+:::

--- a/i18n/de/docusaurus-plugin-content-docs/current/useful-links/index.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/useful-links/index.mdx
@@ -1,0 +1,9 @@
+---
+title: Useful links
+---
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.0.0.json
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.0.0.json
@@ -1,0 +1,42 @@
+{
+  "version.label": {
+    "message": "3.0.0",
+    "description": "The label for version 3.0.0"
+  },
+  "sidebar.sidebar.category.features": {
+    "message": "Funktionen",
+    "description": "The label for category features in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.features.link.generated-index.title": {
+    "message": "Funktionen",
+    "description": "The generated-index page title for category features in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.guides": {
+    "message": "Anleitungen",
+    "description": "The label for category guides in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.guides.link.generated-index.title": {
+    "message": "Anleitungen",
+    "description": "The generated-index page title for category guides in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.useful-links": {
+    "message": "Nützliche Links",
+    "description": "The label for category useful-links in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.useful-links.link.generated-index.title": {
+    "message": "Nützliche Links",
+    "description": "The generated-index page title for category useful-links in sidebar sidebar"
+  },
+  "sidebar.sidebar.link.invite": {
+    "message": "RaidProtect einladen",
+    "description": "The label for link invite in sidebar sidebar, linking to https://raidprotect.bot/invite"
+  },
+  "sidebar.sidebar.link.discord": {
+    "message": "Discord-Server",
+    "description": "The label for link discord in sidebar sidebar, linking to https://raidprotect.bot/discord"
+  },
+  "sidebar.sidebar.link.suggest": {
+    "message": "Funktion vorschlagen",
+    "description": "The label for link suggest in sidebar sidebar, linking to https://suggestions.raidprotect.bot"
+  }
+}

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/changelog.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/changelog.md
@@ -1,0 +1,71 @@
+# Changelog
+
+Discover the detailed list of changes made to RaidProtect.
+
+:::note A major new version is in preparation
+This explains the low number of recent updates. But don't worry, our technical team is always active in case of malfunctions on current versions! ️
+
+To stay updated on the latest news about the upcoming major version, [join our Discord server](https://discord.com/invite/rWEGrNXXzQ).
+:::
+
+## 3.0.0 (01/14/2023)
+
+- Complete rewrite aimed at preparing future updates and stabilizing the bot.
+- Fixed all known bugs to date.
+- The `?raidmode` command now uses the "Disable invites" feature.
+- Automatic sending of a private message to the concerned member when a sanction is applied.
+
+## 2.2.0 (04/13/2020)
+
+- Improved bot performance.
+- Major changes in the project's internal architecture.
+
+## 2.1.3 (10/13/2019)
+
+- Removed the blacklist and associated commands.
+- Added the ability to ban any user by their ID, even if they are not in the server.
+- Displayed the ban reason in the response of the `?ban` command.
+- The `?raidmode` command now requires the "kick members" permission.
+- Changed the kick timeout if the captcha is not completed (5 minutes).
+- Various internal improvements.
+
+## 2.1.2 (04/17/2019)
+
+- Added the `?userinfo` command.
+- ~~Added `?lockall` and `?unlockall` commands~~ (Feature removed).
+- Added `?kick` and `?ban` commands.
+- Introduced minimum account age for captcha (option to set a minimum account age to access the server).
+- Added the ability to auto-delete command invocation messages.
+- Logs channel now automatically recreates if deleted.
+- Reworked database connection.
+- Bug fixes and various improvements.
+
+## 2.1.1 (02/21/2019)
+
+- Removed `?settings captcha` (replaced with `?captcha`).
+- Added the ability to define a logs channel for captcha.
+- Added an autorole compatible with captcha.
+- Simplified captcha (5/6 correct letters required).
+- Other minor changes.
+
+## 2.1.0 (02/16/2019)
+
+- Introduced captcha (`?settings captcha`).
+- Added spam security level (`?settings spamlevel`).
+- Added `?about` and `?invite` commands.
+- Added `?clear` command.
+- Various changes and bug fixes.
+
+## 2.0.1 (02/04/2019)
+
+- Rewrote the help command (`?help`).
+- Fixed bugs in `?lock` and `?unlock`.
+
+## 2.0.0 (01/26/2019)
+
+- Introduced anti-spam.
+- Added automatic raid mode.
+- Added logs channel.
+- Added bot configuration.
+- Added channel locking.
+- Numerous other changes.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/features/anti-spam.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/features/anti-spam.md
@@ -1,0 +1,43 @@
+---
+title: Anti-spam
+---
+
+Easily and effectively protect your Discord server with RaidProtect's anti-spam feature.
+
+## ❓ How the Anti-Spam Works {#working}
+
+**RaidProtect’s anti-spam system automatically bans spammers and raiders from your server without any intervention on your part.** It detects both heavy and light spam and can act quickly to stop it, depending on your server's configuration. 🤚 
+
+:::warning
+**Heavy spam typically involves raid-like behavior, including invitation links, mentions, or images.** RaidProtect distinguishes heavy spam from light spam and applies different sanctions accordingly.
+:::
+
+**If spam is detected, RaidProtect kicks the spammer** and informs you via the logs channel. You can view details of the blocked spam by clicking on the provided link.
+
+![Spam Log Screenshot](../assets/log-spam-raidprotect.png)
+
+## 📈 Anti-Spam Security Levels {#level}
+
+RaidProtect's anti-spam system offers multiple security levels, allowing you to **adjust its behavior, particularly in ignored channels.** 👮 
+
+### Available Security Levels {#level-list}
+
+🔴 **High (`high`):** Detects both light and heavy spam. In ignored channels, only heavy spam is blocked.
+
+🔶 **Medium (`medium`):** Detects both light and heavy spam. In ignored channels, all types of spam are allowed.
+
+💚 **Low (`low`):** Only blocks heavy spam. In ignored channels, all types of spam are allowed.
+
+### Changing the Security Level {#level-change}
+
+To change the anti-spam security level, use the following command: `?settings spamlevel [high/medium/low]`.
+
+## 💤 Ignoring a Channel {#ignore-channel}
+
+For various reasons, you might want the anti-spam system to ignore certain channels on your server. Fortunately, it’s easy to exclude channels of your choice. 😝 
+
+The anti-spam system’s behavior in ignored channels depends on the configured security level.
+
+To ignore a channel, simply run the command: `?settings allowspam #channel` (replace `#channel` with the channel you want to ignore). To include the channel again, use the command: `?settings allowspam #channel remove`.
+
+Channels with `spam` in their name are automatically ignored.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/features/captcha.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/features/captcha.md
@@ -1,0 +1,58 @@
+---
+title: Captcha (Verification)
+---
+
+Prevent selfbots from accessing your Discord server and block raids with RaidProtect's captcha verification system.
+
+The captcha is one of the most popular features of RaidProtect, yet it is **entirely optional**. If needed, the captcha allows you to require each user to complete a challenge by entering a code to confirm they are not a bot (_selfbot_).
+
+While this enhances your server's security, **some users may not understand the process**, which could result in losing a few members. It’s up to you to decide if it’s worth implementing! 😉  
+
+## ❓ How the Captcha Works {#working}
+
+**The captcha uses an "Unverified" role and a #verification channel.** When a user joins, the bot assigns them the "Unverified" role, restricting their access to only the #verification channel. In this channel, **the bot sends an image containing six letters**, and the user must type what they see to prove they are not a bot. If the input is correct—allowing for one incorrect letter—the bot removes the "Unverified" role, granting the user normal access to the server. 👾  
+
+Users have five minutes to complete the captcha. After this time, they are kicked from the server to prevent cluttering the verification channel with orphaned messages.
+
+:::warning
+**The permissions for the "Unverified" role are managed automatically by RaidProtect.** While you can rename the role and channel, they must not be deleted.
+:::
+
+![How the Captcha Works](../assets/captcha-raidprotect.gif)
+
+When a user joins your server with the captcha enabled, RaidProtect automatically posts **a message with the account creation date** of the new user in the logs channel.
+
+![Join Log Screenshot](../assets/log-join-captcha-raidprotect.png)
+
+## ⛽ Setting Up the Captcha {#setup}
+
+**Setting up the captcha is effortless!** Simply use the command `?captcha enable`, and everything will be configured automatically. 🎩  
+
+To disable it, use the command `?captcha disable`. The captcha role and channel will be removed without further intervention.
+
+## ✨ Additional Features {#additional-features}
+
+To make the captcha system more flexible, we’ve added **several additional options.** 🦸‍♂️  
+
+### Separate Logs {#logs}
+
+By default, captcha logs are posted in the RaidProtect logs channel. If your server is popular, these messages may overwhelm the other logs. **You can move them to another channel!**
+
+After creating a new logs channel, use the command `?captcha logs #logs-channel`. All captcha logs will now appear in the new channel.
+
+### Automatic Role Assignment {#autorole}
+
+:::warning
+If you use an automatic role assignment (_autorole_) system other than RaidProtect, **the captcha may no longer work.** Replace it with RaidProtect’s autorole feature to resolve this issue. 👷  
+:::
+
+By default, users do not receive any role after passing the captcha. However, you can **assign a role automatically**. To do so, run the command:  
+`?captcha autorole @role`.  
+
+The role can either be a mention or the exact name of a role.
+
+### Minimum Account Age {#minage}
+
+You can enforce a **minimum account age requirement to access your server.** Any user with an account younger than this will be automatically kicked. 👶  
+
+To enable this feature, use the command: `?captcha min-age [minimum age]`. The minimum age must be specified in days.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/features/others.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/features/others.md
@@ -1,0 +1,31 @@
+---
+title: Others
+---
+
+Explore all the secondary features of RaidProtect: moderation, channel locking, user information, and more.
+
+In addition to the main features previously introduced, RaidProtect offers **a few additional minor features**. They are simple yet useful! 😯  
+
+## 🤬 Moderation Commands {#moderation}
+
+To make life easier for your moderators, RaidProtect includes commands for interacting with Discord’s native moderation features: **banning and kicking users**. In addition to banning or kicking a user (as expected), these commands send a private message to the user explaining the reason for their sanction and log the action in RaidProtect's logs channel. 🗣️  
+
+Using these commands is **very straightforward**. For banning, simply run: `?ban @user reason`. The `?kick` command follows the same format. For example, to kick the user "Evil" for "insults," run: `?kick @Evil Insults`. It’s that quick!
+
+For advanced users, note that you can ban a user even **if they are not on your server** by using their user ID. Convenient.
+
+![Ban Log Screenshot](../assets/log-ban-raidprotect.png)
+
+Example of a log message after banning a user.
+
+## 🔒 Channel Locking {#lock}
+
+Sometimes, you may need—for any reason—to lock a channel to **prevent members from speaking in it.** The lock command allows you to do this quickly: run `?lock`, and the channel is locked! To reverse the action, simply use the command `?unlock`.
+
+This command **removes the permission to speak** from the @everyone role in the channel. For it to work effectively, make sure no other role has explicit permission to speak in the channel; otherwise, those with such roles will still be able to talk.
+
+## 👤 User Information {#userinfo}
+
+The final additional feature is the `?userinfo` command. This command primarily allows you to view **the account creation date of any user** and, if they are a server member, the date they joined your server. The command must be followed by a mention, a username with a tag, or a user ID. 👀  
+
+![User Info Screenshot](../assets/userinfo-raidprotect.png)

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/features/raid-mode.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/features/raid-mode.md
@@ -1,0 +1,30 @@
+---
+title: Raid Mode
+---
+
+Raid Mode is an emergency feature designed to block all new users attempting to join your server. It’s a radical but effective way to prevent raid attempts. 💣  
+
+## ❓ How Raid Mode Works
+
+Once Raid Mode is activated, all new users will be **instantly kicked**, and RaidProtect will notify them that the server is in Raid Mode.
+
+**To activate Raid Mode,** a user with the permission to kick members must run the `?raidmode` command. A message will be posted in the logs to indicate its activation. Be aware that **Raid Mode does not deactivate automatically**, so remember to turn it off using the same command. 😇  
+
+![Raid Mode Activated Screenshot](../assets/raidmode-active-raidprotect.png)
+
+## 📡 Automatic Raid Mode
+
+If a large number of users join your server within a very short period, RaidProtect can **automatically activate Raid Mode**.
+
+### ⛽ Configuration
+
+By default, Raid Mode is triggered if **more than 10 users join your server within 10 seconds.** If your server frequently receives a large influx of members simultaneously, it might be wise to adjust this setting to avoid false positives.
+
+![Automatic Raid Mode Screenshot](../assets/raidmode-auto-raidprotect.png)
+
+The adjustable parameter is **the number of users allowed to join** within a 10-second timeframe before triggering Raid Mode. For example, by running the command:  
+`?settings autoraidmode 20`, Raid Mode will activate if more than 20 users join your server within 10 seconds. 🍃  
+
+:::warning
+Don’t forget to **turn off Raid Mode** if it activates automatically. Remember, it does not deactivate on its own. 😖  
+:::

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/guides/report-violation-to-discord.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/guides/report-violation-to-discord.md
@@ -1,0 +1,37 @@
+---
+title: Report a violation to Discord
+---
+
+Have you encountered a malicious user on Discord? Report them to ensure appropriate action is taken.
+
+On Discord, some users may not have the best intentions. If their behavior is particularly harmful to the community, it’s recommended to **report them to Discord’s Trust & Safety team**. If the violation is confirmed, the user may face penalties ranging from warnings to account termination. 😖  
+
+## 🧐 What Types of Violations Should Be Reported? {#types-of-violations}
+
+Of course, not all types of violations warrant account termination. Punishable behaviors are outlined in **Discord’s [Community Guidelines](https://discord.com/guidelines)** (as well as in the [Terms of Service](https://discord.com/terms), though the latter is more legal jargon than clear instructions). The list of report categories on the submission page is an excellent summary for those reluctant to read everything.
+
+In general, behaviors that are **harmful to the community** (spam, promotion of illegal content, etc.) or cause **serious harm to a user** (doxxing, harassment) should be reported.
+
+For less severe behavior, consider using **bans** (on a server) or [blocking](https://support.discord.com/hc/en-us/articles/217916488-Blocking-Privacy-Settings) (platform-wide). If you’re not a moderator on the server where the incidents occur, report the behavior to the server’s moderation team, as they are obligated to take action.
+
+## 🕵️ Gathering Evidence {#recover-evidences}
+
+To make a report, you’ll need to provide evidence. Note that **screenshots are not valid proof** as they can be easily forged. You must provide a link (or multiple links) to the offending messages.
+
+**These links are easy to obtain.** On a message that corresponds to the violation you want to report, right-click > Copy Message Link (on desktop) or long-press > Share > Copy to Clipboard (on mobile).
+
+## 📪 Reporting the Violation to the Trust & Safety Team {#report-to-tns}
+
+Reporting is quick and straightforward, taking only a few minutes. First, go to the **dedicated form** by visiting **[https://dis.gd/report](https://dis.gd/report)**.
+
+![Discord Report Form Screenshot](../assets/discord-report.png)
+
+### Submitting the Report to the Trust & Safety Team {#form}
+
+Depending on the type of report, **different details will be required**. Paste the message link(s) you retrieved earlier in the appropriate field (and add others in the description, if necessary). Be sure to be **as thorough as possible** and maintain polite communication. 😇  
+
+### 📨 Discord’s Response {#discord-response}
+
+A few days after submitting your report—usually within a week—you should receive **an email response** from Discord. Note that you won’t be informed about the specific penalties (if any) imposed on the reported user. 😒  
+
+![Discord Reply Screenshot](../assets/discord-reply.png)

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/malfunctions.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/malfunctions.md
@@ -1,0 +1,63 @@
+---
+title: Malfunctions
+---
+
+Encountering an issue with RaidProtect? The solution is likely here.
+
+Sometimes, things don’t go as expected. Here are the **most common problems** you might encounter and how to resolve them. 🤗  
+
+If this page doesn’t address the issue you’re facing, **don’t hesitate to contact our support team**, who will gladly assist you!
+
+## The bot shows an error when I use a command {#commands}
+
+If a command doesn’t execute successfully, **RaidProtect might display an error** instead of the expected result. In most cases, the message will explain the issue, but sometimes it might be more generic. Here’s how to resolve the issue in most cases. 🧐  
+
+- **Follow the instructions.** Some errors clearly explain the problem. If the bot asks you to do something, follow the instructions provided.  
+
+- **Check the command parameters.** Ensure the command is correctly written. Refer to the help documentation if needed. Remember, brackets (`[]`) are not meant to be included in your command.  
+
+- **Verify the bot’s permissions.** The bot must have Administrator permissions and be ranked at the same level as administrators in the role hierarchy.  
+
+- **Retry the command.** Occasionally, the issue resolves itself without any apparent reason.  
+
+If the error persists despite following these steps, reach out to our support team for further assistance. 🤝  
+
+## The bot’s logs channel wasn’t created automatically {#logs}
+
+To notify you of its actions, RaidProtect requires a logs channel. This channel is automatically created when the bot first joins the server, but sometimes, it doesn’t appear. Here’s how to fix this! ⚙️  
+
+- **Ensure the bot has Administrator permissions.** The bot requires Administrator access to function correctly. If it doesn’t have this, go to your server's role settings and grant this permission to RaidProtect’s role. Once permissions are configured, manually initialize the bot as described below.  
+
+- **Check the bot’s initialization.** This process is typically automatic, but you can manually initialize the bot by running the `?setup` command. The logs channel should then be created.  
+
+- **Set a logs channel manually.** If nothing works, don’t worry! You can manually assign a channel for the logs. Create a dedicated channel, then run the command `?settings logs #channel`, replacing `#channel` with your new logs channel.  
+
+## A user spammed, but the bot didn’t take action {#anti-spam}
+
+Anti-spam is one of RaidProtect’s core features, and it can be frustrating if it doesn’t work as expected. Fortunately, the issue is usually easy to fix. 😇  
+
+- **If the anti-spam detects spam but doesn’t act,** it’s likely due to insufficient permissions. Ensure the bot has Administrator permissions and is ranked at the same level as administrators in the role hierarchy.  
+
+- **Check the anti-spam configuration.** It might seem trivial, but some users forget they’ve excluded certain channels from detection.  
+
+- **Verify the spammer’s permissions.** Administrators are ignored by the anti-spam system. If you’re testing on your own server, the bot might not detect your spam.  
+
+- **Is the spam significant enough?** The bot usually detects spam after more than five messages. Be patient when testing.  
+
+If the anti-spam still doesn’t respond to spam, contact us on our support server with a **screenshot of the issue**.  
+
+## Users bypass the captcha {#captcha}
+
+This issue is relatively common and often relates to **your server’s configuration**. Here’s how to fix it. 🏥  
+
+- **Do you have an autorole?** If another bot is assigning a role to new users, it might interfere with the captcha. Replace it with [RaidProtect’s autorole](./features/captcha.md#autorole).  
+
+- **Is the captcha enabled?** This feature is optional and requires a command to activate. Refer to the captcha documentation for more details.  
+
+## Users can still chat when I lock a channel {#lock}
+
+The lock command is useful but has limitations. As noted in [this documentation](./features/others.md#lock), the command **only affects the @everyone role**. This means if another role explicitly has permission to chat in the locked channel, members with that role will still be able to speak.  
+
+As a picture is worth a thousand words, here’s a visual example of what this looks like. 🔍  
+
+![Screenshot of channel lock configuration](./assets/lock-channel-messages-raidprotect.png)

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/quick-guide.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/quick-guide.mdx
@@ -1,0 +1,52 @@
+---
+title: Quick Guide
+---
+
+import DocCard from '@theme/DocCard';
+
+Need to get started quickly with RaidProtect? This page summarizes the key information you need to know.
+
+Welcome to the RaidProtect Quick Guide! **This page condenses the essential information** to get started with the bot. For more details on each feature, refer to the rest of the documentation. 📚 
+
+First, you need to invite RaidProtect and **properly configure its permissions**. This crucial step is outlined on the documentation's homepage.
+
+<DocCard item={{ type: 'link', href: '/3.0.0', label: 'Read Me' }} />
+<br />
+
+Once the permissions are correctly configured (without which the bot may not function effectively), you can start exploring the various features! 🤠 
+
+## 💬 Anti-Spam {#antispam}
+
+One of RaidProtect's main features is its anti-spam system. It enables you to **block spam attempts within seconds**, without any manual intervention.
+
+The anti-spam system takes multiple parameters into account to determine the severity of the spam and decide whether to take action. **If spam is detected, the bot kicks the spammer** and notifies you in the logs channel. 🙌 
+
+In some cases, you might want to **exclude certain channels from spam detection**. To do this, simply run the command `?settings allowspam #channel-to-ignore`. For more details about the anti-spam system, refer to the detailed documentation!
+
+<DocCard item={{ type: 'link', href: '/3.0.0/features/anti-spam', label: 'Anti-Spam' }} />
+
+## 💢 Raid Mode {#raidmode}
+
+Sometimes, a group of users may threaten your server, and drastic measures are required. Raid Mode is here to help! It allows you to **temporarily block all users attempting to join your server**. It’s effective but should be reserved for serious situations. 🤩 
+
+**Activating Raid Mode is incredibly simple**, allowing you to respond quickly to threats. Just run the `?raidmode` command in any channel, and Raid Mode will be enabled. **Don’t forget to disable it** using the same command!
+
+To make this protection even more effective, RaidProtect can detect a massive influx of new users and **activate Raid Mode automatically** (though it won’t disable it). If your server is highly popular, you may need to adjust the sensitivity settings—refer to the detailed documentation for more information.
+
+<DocCard item={{ type: 'link', href: '/3.0.0/features/raid-mode', label: 'Raid Mode' }} />
+
+## 🚧 Captcha {#captcha}
+
+Finally, we have RaidProtect's captcha feature—a popular and essential tool. Think of the "I'm not a robot" checkboxes. Our captcha serves a similar purpose but for your Discord server. It **displays a code for new users to complete**, stopping bots disguised as regular accounts (_selfbots_). 🕵️ 
+
+**This feature is entirely optional**, and you may not need it. If you want to use it, simply enable it by running the command `?captcha enable`. Everything else is automated!
+
+If your server uses a Member role and a bot to assign it automatically (_autorole_), **this might interfere with the captcha**. Fortunately, we’ve planned for this. Check out the detailed captcha documentation to explore optional settings.
+
+<DocCard item={{ type: 'link', href: '/3.0.0/features/captcha', label: 'Captcha (Verification)' }} />
+
+## 😵 It’s Not Working! {#errors}
+
+Whether it’s a malfunction or a configuration issue, things don’t always go as planned. Fortunately, we’re here to help! **Start by checking the page on common issues** in this documentation. If the problem persists, our team will be happy to assist. Join our Discord server to contact us. 👨‍🔧 
+
+<DocCard item={{ type: 'link', href: '/3.0.0/malfunctions', label: 'Common Issues' }} />

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/readme.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/readme.mdx
@@ -1,0 +1,49 @@
+---
+title: Read Me
+slug: /
+---
+
+import DocCard from '@theme/DocCard';
+
+Need help using RaidProtect? You'll find all the information you need in our documentation!
+
+Welcome to the RaidProtect documentation! This guide is designed to help you understand how RaidProtect works. Feel free to share your feedback so we can continue to improve it.
+
+Don't forget to join our Discord server to **stay updated on the latest news about the project**. You'll also be able to reach out to our support team, who will answer your questions about using the bot. 😄 
+
+## 🚀 Getting Started with RaidProtect {#start}
+
+To start using RaidProtect, simply **invite it to your server** using the following link. Be cautious of copies—only invite it from our official website.
+
+:::note
+To ensure proper functionality, make sure to grant RaidProtect the **Administrator** permission. This allows it to automatically moderate all your channels.
+
+Also, make sure to **place its role at the same level as your server administrators** (see the image below). The permissions system prevents RaidProtect from taking action against users with a higher role.
+
+![Role Screenshot](./assets/role-raidprotect.png)
+:::
+
+That's it, **RaidProtect is now on your Discord server**! A channel named `#raidprotect-logs` has been created. Do not delete this channel—it is essential for the bot to function. If you already have a logs channel, you can change the RaidProtect logs channel with the command `?settings logs #new-channel`.
+
+:::note
+**If the logs channel wasn't created automatically**, you'll need to manually set up the bot by running the `?setup` command in your server.
+:::
+
+Check out the various sections of this documentation to **explore all the features offered** by the bot! 😎 
+
+<DocCard item={{ type: 'link', href: '/3.0.0/features/anti-spam', docId: 'features/anti-spam', label: 'Anti-Spam' }} />
+<br />
+<DocCard item={{ type: 'link', href: '/3.0.0/features/captcha', docId: 'features/captcha', label: 'Captcha (Verification)' }} />
+<br />
+<DocCard item={{ type: 'link', href: '/3.0.0/features/raid-mode', docId: 'features/raid-mode', label: 'Raid Mode' }} />
+<br />
+<DocCard item={{ type: 'link', href: '/3.0.0/features/others', docId: 'features/others', label: 'Others' }} />
+<br />
+
+For those in a hurry (or less adventurous), you can check out our quick guide, which summarizes the key information to get started. 😉 
+
+<DocCard item={{ type: 'link', href: '/3.0.0/quick-guide', docId: 'quick-guide', label: 'Quick Guide' }} />
+
+## 👥 About the Project {#about}
+
+RaidProtect is a free and community-driven project that started in July 2018. Created by [baptiste0928](https://baptiste0928.net/), the project quickly gained a large user base and now boasts a team of around fifteen volunteers, especially for user support.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.0.json
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.0.json
@@ -1,0 +1,30 @@
+{
+  "version.label": {
+    "message": "3.1.0",
+    "description": "The label for version 3.1.0"
+  },
+  "sidebar.sidebar.category.features": {
+    "message": "Funktionen",
+    "description": "The label for category features in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.guides": {
+    "message": "Anleitungen",
+    "description": "The label for category guides in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.useful-links": {
+    "message": "Nützliche Links",
+    "description": "The label for category useful-links in sidebar sidebar"
+  },
+  "sidebar.sidebar.link.invite": {
+    "message": "RaidProtect einladen",
+    "description": "The label for link invite in sidebar sidebar, linking to https://raidprotect.bot/invite"
+  },
+  "sidebar.sidebar.link.discord": {
+    "message": "Discord-Server",
+    "description": "The label for link discord in sidebar sidebar, linking to https://raidprotect.bot/discord"
+  },
+  "sidebar.sidebar.link.suggest": {
+    "message": "Funktion vorschlagen",
+    "description": "The label for link suggest in sidebar sidebar, linking to https://suggestions.raidprotect.bot"
+  }
+}

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/changelog.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/changelog.mdx
@@ -1,0 +1,92 @@
+---
+title: Changelog
+---
+
+import SuggestionLink from '@site/src/components/SuggestionLink';
+
+Discover the detailed list of changes made to RaidProtect.
+
+## 3.1.0 (12/03/2025) {#3-1-0}
+
+- Added **Slash Commands**. <SuggestionLink id="463" />
+- [Internationalization](./language.md) (added English). <SuggestionLink id="109" />
+- New feature [`/report`](./features/reports.md). <SuggestionLink id="164" />
+- New configuration commands:
+  - [`/settings`](./setup.md#settings) as an interactive panel.
+  - [`/setup`](./setup.md#install) as an Onboarding process.
+- Advanced settings:
+  - Enable/disable each feature individually. <SuggestionLink id="356" />
+  - Choose the delay and number of attempts before expulsion by the [captcha](./features/captcha#config). <SuggestionLink id="363" />
+  - Option to select the verification channel for the [captcha](./features/captcha). <SuggestionLink id="385" />
+  - Ignore users/roles/categories in the [anti-spam](./features/anti-spam.md#ignore). <SuggestionLink id="362" />
+  - Choose the [prefix for hybrid commands](./guides/prefix.md). <SuggestionLink id="103" />
+  - Option to choose whether the [`/lock` command](./features/channel-lock.md) renames the locked channel with `🔒`.
+- Improved UX:
+  - Prefix displayed when pinging the bot + mention as a universal prefix. <SuggestionLink id="193" />
+  - Disabling the [captcha](./features/captcha) no longer deletes the associated role and channel. <SuggestionLink id="43" />
+  - Automatic detection of permission issues related to channels and roles. <SuggestionLink id="65" />
+  - Automatic visibility check of the verification channel in Discord's onboarding process.
+  - Standardized messages.
+- Improved bot performance and stability.
+
+## 3.0.0 (01/14/2023) {#3-0-0}
+
+- Complete rewrite aimed at preparing for future updates and stabilizing the bot.
+- Fixed all known bugs to date.
+- The [`?raidmode` command](./features/raid-mode.md) now uses the "Disable Invites" feature.
+- Automatic sending of a private message to the concerned member when a sanction is applied. <SuggestionLink id="426" />
+
+## 2.2.0 (04/13/2020) {#2-2-0}
+
+- Improved bot performance.
+- Significant changes to the project's internal architecture.
+
+## 2.1.3 (10/13/2019) {#2-1-3}
+
+- Removed the blacklist and associated commands.
+- Ability to ban any user by their ID, even if they are not in the affected server. <SuggestionLink id="113" /> <SuggestionLink id="148" />
+- Display of the ban reason in the response of the [`?ban` command](./features/moderation.md#ban).
+- The [`?raidmode` command](./features/raid-mode.md) now requires the permission to kick members.
+- Changed the kick duration if the captcha is not completed (5 min). <SuggestionLink id="129" />
+- Various internal improvements.
+
+## 2.1.2 (04/17/2019) {#2-1-2}
+
+- Added the [`?userinfo` command](./features/utilities.md#userinfo). <SuggestionLink id="29" />
+- ~~Added the `?lockall` and `?unlockall` commands~~ (Feature removed).
+- Added the [`?kick`](./features/moderation.md#kick) and [`?ban`](./features/moderation.md#ban) commands.
+- Added [min-age to the captcha](./features/captcha.md#minage) (ability to set a minimum account age to access the server).
+- Option to configure automatic deletion of command invocation messages. <SuggestionLink id="26" />
+- The logs channel is automatically recreated if deleted.
+- Overhauled database connection.
+- Bug fixes and various improvements.
+
+## 2.1.1 (02/21/2019) {#2-1-1}
+
+- Removed `?settings captcha` (replaced by `?captcha`).
+- Added the ability to set a [logs channel](./features/captcha.md#logs) for the captcha.
+- Added an [autorole](./features/captcha.md#autorole) compatible with the captcha.
+- Simplified the [captcha](./features/captcha.md) (5/6 correct letters required).
+- Other minor changes.
+
+## 2.1.0 (02/16/2019) {#2-1-0}
+
+- Added captcha (`?settings captcha`). <SuggestionLink id="11" />
+- Added anti-spam security level (`?settings spamlevel`). <SuggestionLink id="25" />
+- Added the `?about` and `?invite` commands.
+- Added the [`?clear` command](./features/utilities.md#clear).
+- Various changes and bug fixes.
+
+## 2.0.1 (02/04/2019) {#2-0-1}
+
+- Rewrote the help (`?help`).
+- Fixed bugs in [`?lock`](./features/channel-lock.md#lock) and [`?unlock`](./features/channel-lock.md#unlock).
+
+## 2.0.0 (01/26/2019) {#2-0-0}
+
+- Added [anti-spam](./features/anti-spam.md).
+- Added [automatic raid mode](./features/raid-mode.md#config).
+- Added the logs channel.
+- Added bot configuration.
+- Added [channel locking](./features/channel-lock.md).
+- Numerous various changes.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/features/anti-spam.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/features/anti-spam.md
@@ -1,0 +1,44 @@
+---
+title: Anti-spam
+---
+
+RaidProtect's Anti-spam is a powerful tool to prevent spam on your Discord server. Thanks to its automatic detection system, it handles issues on its own without requiring your intervention.
+
+## ❓ How the Anti-spam Works {#working}
+
+RaidProtect's anti-spam detects and automatically blocks suspicious behavior. It distinguishes between two types of spam.
+- **Heavy spam:** Messages containing invitation links, mass mentions, or images. This type of spam is often used during raids.
+- **Light spam:** Messages sent frequently but less intrusive.
+
+RaidProtect's anti-spam acts in two ways.
+- **Sanctions:** Automatic kicking or banning of spammers.
+- **Notifications:** Sends messages to the log channel to report blocked spam with an overview of detected actions.
+
+## 🛡️ Configuring the Anti-spam {#config}
+
+RaidProtect offers three security levels to meet your server's needs.
+- 🔴 **High:** Sanctions all spam, including heavy spam in ignored channels.
+- 🟠 **Medium:** Sanctions all spam but respects ignored channels.
+- 🟢 **Low:** Sanctions only heavy spam.
+
+### Changing the Security Level {#level}
+
+1. Use the [`/settings` command](../setup.md#settings).
+2. Click on the “**Anti-spam**” button.
+3. Select the desired anti-spam level from the first dropdown.
+
+### Managing Ignored Roles, Users, and Channels {#ignore}
+
+You can exclude certain channels, roles, or even users from anti-spam monitoring for added flexibility. 😉
+1. Use the [`/settings` command](../setup.md#settings).
+2. Click on the “**Anti-spam**” button.
+3. Select the different options to ignore in the dropdowns:
+- Channel(s) to ignore
+- Role(s) to ignore
+- Member(s) to ignore
+
+![Anti-spam settings screenshot](../assets/rpBeta-settings-anti-spam.webp)
+
+:::info
+Channels containing “**spam**” in their name are automatically ignored. Users with administrator permissions are completely ignored.
+:::

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/features/captcha.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/features/captcha.md
@@ -1,0 +1,66 @@
+---
+title: Captcha (Verification)
+---
+
+Prevent selfbots from accessing your Discord server and block raids with RaidProtect's captcha system.
+
+Captcha is one of RaidProtect's most popular features, though it remains entirely optional. It allows you to require each new user to complete a challenge by entering a code to verify that they are not a bot (selfbot).
+
+## ❓ How Captcha Works {#working}
+
+Captcha relies on a **@Unverified** role and a **#verification** channel. When a user joins your server:
+- The bot automatically assigns the **@Unverified** role to this user, limiting their access only to the **#verification** channel.
+- In this channel, the bot sends an image containing 6 uppercase letters. The user must transcribe the letters in the channel to prove they are human.
+- If the response is correct, the **@Unverified** role is removed, and the user gains normal access to the server. Otherwise, they are automatically kicked.
+- When captcha is enabled, RaidProtect automatically posts a message in the logs channel, indicating the account creation date of each new user.
+- RaidProtect automatically detects permission issues (channel and role) as well as the default visibility of the channel during Discord's onboarding process.
+
+:::info
+**Time Limit and Attempts:** Users have **1 to 10 minutes** to complete captcha (**5 minutes by default**) and **1 to 3 attempts** (**2 attempts by default**). If they exceed these limits, they are automatically kicked from the server.
+:::
+:::warning
+**Permission Management:** The permissions for the **@Unverified** role are automatically configured by RaidProtect. You can rename the role and the channel, but do not delete them.
+:::
+
+## 🚪 Captcha Configuration {#config}
+
+Setting up captcha is quick and easy.
+
+1. Run the [`/settings` command](../setup.md#settings).
+2. Click the "**Captcha**" button.
+3. Choose the channel where captchas will be conducted or use the "**Create one for me**" button.
+4. The **@Unverified** role is automatically created and configured.
+5. Configure the allowed number of attempts (between **1 and 3**) and the maximum resolution time (between **1 and 10 minutes**).
+
+![Captcha settings screenshot](../assets/rpBeta-settings-anti-captcha.webp)
+
+## ✨ Additional Features {#additional-features}
+
+To adapt to your server's needs, RaidProtect's captcha offers customizable options.
+
+### Separate Logs {#logs}
+
+If your server is popular, captcha-related logs may clutter your main logs channel. You can move them to another channel.
+
+1. Run the [`/settings` command](../setup.md#settings).
+2. Click the "**Logs**" button.
+3. Select "**Captcha**".
+4. Choose the channel where captcha logs will be stored or use the "**Create one for me**" button.
+
+### Auto Role {#autorole}
+
+If you use an automatic role (autorole) system other than RaidProtect, it may interfere with captcha. Replace your existing autorole with RaidProtect's.
+
+1. Run the [`/settings` command](../setup.md#settings).
+2. Click the "**Captcha**" button.
+3. Select "**Auto Role**".
+4. Choose the role that will be assigned to members who successfully complete captcha.
+
+### Minimum Account Age {#minage}
+
+To enhance security, you can require a minimum account age for new Discord members.
+
+1. Run the [`/settings` command](../setup.md#settings).
+2. Click the "**Captcha**" button.
+3. Press the "**Minimum Age**" button.
+4. Select the desired value from the dropdown menu or choose a custom value expressed in date format (m/h/d/y).

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/features/channel-lock.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/features/channel-lock.md
@@ -1,0 +1,32 @@
+---
+title: Channel locking
+---
+
+Sometimes it is necessary to temporarily lock a channel to prevent users from sending messages. With the lock command, this becomes a breeze!
+
+## 🔒 Lock a Channel {#lock}
+
+Use the command: ```/lock```
+
+This will remove the speaking permission from the **@everyone** role in the channel, preventing all users from posting in that channel.
+
+## 🔓 Unlock a Channel {#unlock}
+
+Use the command: ```/unlock```
+
+This will add the speaking permission back to the **@everyone** role in the channel, allowing all users to post in that channel.
+
+:::warning
+For the lock command to work properly, you must ensure that no roles have explicit permission to speak in that channel. Otherwise, members with those roles will still be able to chat.
+:::
+:::info
+The `lock` and `unlock` commands are [usable by prefix](../guides/prefix.md).
+:::
+
+## ✏️ Configuring the Lock Icon {#config}
+
+By default, this feature is disabled. However, you can choose whether locked channels should be renamed with a lock emoji (🔒) added in front of their name.
+
+To enable/disable the lock icon in front of the names of locked channels:  
+1. Use the [command `/settings`](../setup.md#settings).
+2. Click on the **Lock Icon on Locked Channels** button. This button acts as a toggle; a simple click is enough to enable or disable the option.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/features/index.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/features/index.mdx
@@ -1,0 +1,9 @@
+---
+title: Features
+---
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/features/moderation.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/features/moderation.md
@@ -1,0 +1,27 @@
+---
+title: Moderation
+---
+
+To facilitate the work of your moderators, RaidProtect integrates very useful moderation commands that allow you to interact directly with Discord's native features, such as **banning** and **kicking** users.
+
+In addition to these actions, RaidProtect sends direct messages to the sanctioned user to explain the reason for their sanction, and this is also recorded in the server logs for your reference.
+
+:::info
+Moderation commands are [usable by prefix](../guides/prefix.md).
+:::
+
+## 🔨 Ban a User {#ban}
+
+Use the command: ```/ban [@user] [reason]```
+
+Replace `[@user]` with the desired mention or ID and `[reason]` with the reason for the sanction.
+
+:::tip
+You can ban a user using their [Discord ID](https://dfr.gg/wiki/interface/mode-developpeur), even if they are not currently online or present on your server.
+:::
+
+## 👢 Kick a User {#kick}
+
+Use the command: ```/kick [@user] [reason]```
+
+Replace `[@user]` with the desired mention or ID and `[reason]` with the reason for the sanction.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/features/raid-mode.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/features/raid-mode.md
@@ -1,0 +1,46 @@
+---
+title: Raid mode
+---
+
+Raid mode is an emergency feature designed to instantly block all new users attempting to join your server. It is radical but effective in preventing mass raids. With RaidProtect's raid mode, you have an effective shield against massive attacks on your server. 🌟
+
+## ❓ How Raid Mode Works {#working}
+
+RaidProtect automatically activates raid mode if a large number of users join your server in a short period. By default, raid mode activates if more than 10 users join your server in less than 10 seconds. When raid mode is activated, no users can join the server. They are blocked at the invitation level.
+
+:::warning
+Discord’s Community features are essential for Raid mode to function properly. [Follow our guide to verify that Community is enabled on your server.](../guides/community.md)
+:::
+
+### Activation {#enable}
+
+- To manually activate this mode, a user with kick permissions must execute the command `/raidmode`.
+- A message will be automatically posted in the logs channel to indicate activation.
+
+### Deactivation {#disable}
+
+Raid mode does not deactivate automatically. Be sure to turn it off with the same command when the threat has passed. 😇
+
+:::info
+The `raidmode` command is [usable with a prefix](../guides/prefix.md).
+:::
+
+## 🚨 Configuring Automatic Raid Mode {#config}
+
+If your server frequently hosts many new members simultaneously, it is wise to adjust this threshold to avoid false positives.
+
+[Screenshot of automatic raid mode](../assets/rpBeta-settings-raid-mode.webp)
+
+:::note
+We recommend entering a value between 10 and 20 members in 10 seconds for good system efficiency.
+:::
+
+1. Use the [command `/settings`](../setup.md#settings).
+2. Click the “**Auto RaidMode**” button.
+3. Select the number of members who can join within 10 seconds.
+
+You can leave the default value (10) or adjust it to the desired value by clicking the “**Custom Value**” button.
+
+:::warning
+If raid mode activates automatically, remember to disable it once the threat has passed. Keep in mind, it does not turn off by itself. 😖
+:::

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/features/reports.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/features/reports.md
@@ -1,0 +1,61 @@
+---
+title: Reports
+---
+
+The RaidProtect reporting system allows your community to quickly report any problematic content or suspicious users. It operates in two different ways and can be configured to optimize the reporting management process.
+
+## ❓ How Reporting Works {#working}
+Members can report content through 3 main methods.
+
+1. **Right-click on a message**  
+A member can right-click on a message they believe violates the rules, select **`Applications`**, and then click on **`Report Message`**. A popup will appear, allowing the user to add an explanation.
+
+2. **Right-click on a profile**  
+Similarly, a member can right-click on a profile they find problematic, choose **`Applications`**, and then click on **`Report Member`**. A popup will then open to allow the user to provide additional details about the situation.
+
+3. **Slash Command**  
+Members can also report a message or user via the **`/report`** command in any server channel.
+
+Use the command: ```/report [@user] [reason]```
+
+Replace `[@user]` with the desired user and `[reason]` with the reason for the infraction.
+
+## 🚩 Configuring Reports {#config}
+
+Before the reporting system is fully operational, it is imperative to configure a **report channel** where all reports will be sent. You need to set up a log or notification channel to receive alerts regarding reports.
+
+### Setting Up the Channel {#config-channel}
+
+1. Use the [command `/settings`](../setup.md#settings).
+2. Select the **Reports** button.
+3. Click on the **Channel** button.
+4. Choose the desired channel (_e.g. #reports_).  
+If you do not have a suitable channel, you can opt to create one automatically using the **Create one for me** button.
+
+[Screenshot report settings](../assets/rpBeta-settings-reports.webp)
+
+### Configuring the Notification Role {#config-role}
+
+1. Use the [command `/settings`](../setup.md#settings).
+2. Select the **Reports** button.
+3. Click on the **Role** button.
+4. Choose the desired role (_e.g. @Moderator or @Report Ping_).  
+If you do not have a suitable role, you can opt to create one automatically with the **Create one for me** button.
+
+:::warning
+The channel should be restricted to moderators and administrators to ensure proper management of reports.
+:::
+
+## Managing Reports {#manage}
+
+As a community moderator, you can choose to accept or reject a report.
+
+- **✅ Accept a report:** If the report is valid, click the “Accept” button under the alert. This button does not trigger any specific action but indicates to other moderators that you consider this report to be handled, fostering coordination and organization.
+
+- **👁️ View Context:** To view the reported message and see the context, click “View Message” under the alert.
+
+- **❌ Reject a report:** If the report is not legitimate, click the “Reject” button under the alert. Similar to the “Accept” button, no specific action is associated with this button; it merely informs other moderators of your decision.
+
+:::note
+Ensure that your moderators are well-trained in using this feature and encourage your active members to use it responsibly!
+:::

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/features/utilities.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/features/utilities.md
@@ -1,0 +1,28 @@
+---
+title: Utilities
+---
+
+Additional features to simplify the management of your server. 🔧
+
+In addition to core features like the captcha system and anti-raid protection, RaidProtect offers several secondary tools that can make managing your server even smoother.
+
+:::info
+Utility commands are [usable by prefix](../guides/prefix.md).
+:::
+
+## 👤 User Information {#userinfo}
+
+The command `/userinfo` allows you to obtain detailed information about a user, such as their **Discord account creation date** and the **date they joined** your server (if they are a member).
+
+Use the command: ```/userinfo [@user]```
+
+Replace `[@user]` with the desired mention or ID.
+
+## 🧹 Clear a Group of Messages {#clear}
+
+The command `/clear` allows you to quickly delete a certain number of messages in a text channel. You can specify a user to delete only their messages.
+
+Use the command: ```/clear [number] (@user)```
+
+- Replace `[number]` with the number of messages you wish to delete (maximum 100).
+- Add `(@user)` using the mention or ID to target only their messages in the channel.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/guides/community.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/guides/community.md
@@ -1,0 +1,37 @@
+---
+title: Enable Community
+---
+
+Enabling the Community feature unlocks several advanced security settings essential for the proper functioning of some RaidProtect features like **DM Lock** or **Raid Mode**.
+
+## 🚦 Requirements {#requirement}
+
+- You must be an administrator of the Discord server.
+
+## 🚩 Enable Community Features {#steps}
+
+1. **Open your server settings**
+   - Click on the server name at the top left > “Server Settings”.
+
+2. **Go to the “Community” section**
+   - In the sidebar, navigate to the **Enable Community** tab and click **Get Started**.
+
+:::note
+If Community is already enabled on your server, the section will be called **Community Overview**.
+:::
+
+3. **Follow the setup wizard**
+   - Enable email verification for all members.
+   - Enable the explicit content filter.
+   - Set up a rules channel and an updates channel.
+   - Accept the Community Server guidelines.
+
+4. **Complete the setup**
+   - Click “Finish Setup”. The “Community” badge will appear on your server once activation is complete.
+
+![Discord Community activation screenshot](../assets/rp-enable-community.webp)
+
+## 💡 Use DM Lock & Raid Mode modules after activation {#use}
+
+- Run the [`/settings`](../setup.md#settings) command to open the RaidProtect configuration menu.
+- Enable or disable the desired modules (DM Lock, Raid Mode, etc.) from the interactive menu.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/guides/index.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/guides/index.mdx
@@ -1,0 +1,9 @@
+---
+title: Guides
+---
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/guides/malfunctions.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/guides/malfunctions.md
@@ -1,0 +1,61 @@
+---
+title: Malfunctions
+---
+
+Having an issue with RaidProtect? The solution is likely here.
+
+Sometimes things don't work as expected. Here are the **most common problems** you may encounter, along with how to solve them. 🤗 
+
+If this page does not answer a problem you're experiencing, [**feel free to contact our support**](https://raidprotect.bot/discord) who will be happy to help you!
+
+## The bot shows an error when I run a command {#commands}
+
+If the command does not execute successfully, **RaidProtect may display an error** instead of the expected result. In most cases, there will be an indication in the message, but it may be a more generic message. Here’s how to resolve this issue in most cases. 🧐 
+
+- **Do what is indicated.** Some errors clearly explain the problem. If the bot asks you to do something, please do it.
+
+- **Check the command parameters.** The command might simply be misspelled; check the help on how to use it. Remember that brackets ([]) are not to be included.
+
+- **Check the bot's permissions.** The bot must have **Administrator** permission and be at the administrator level in the role hierarchy.
+
+- **Retry the command.** Sometimes the issue resolves itself for unknown reasons.
+
+If you continue to receive an error despite following these tips, [contact our support](https://raidprotect.bot/discord) so we can assist you. 🤝 
+
+## The bot's log channel didn't create itself {#logs}
+
+To notify you of the actions it takes, RaidProtect needs a log channel. This channel is created automatically when the bot first joins, but sometimes no channel is created. Here’s how to remedy this issue. ⚙️ 
+
+- **Ensure the bot is an Administrator.** For the bot to function properly, it must be given Administrator permission. If this is not done, go to the role settings and grant this permission to the RaidProtect role. You then just need to manually initialize the bot for everything to work (see below)!
+
+- **Check that the bot is properly initialized.** This is usually done automatically, but you can force this initialization with the [command `/setup`](../setup.md#install). The log channel should be created automatically.
+
+- **Manually set a channel.** If nothing works, don’t panic; you can manually choose the channel the bot will use for logs! Once a dedicated channel is created, execute the [command /settings](../setup.md#settings) and then select Logs.
+
+## A user spammed, but the bot did not sanction them {#anti-spam}
+
+The [anti-spam](../features/anti-spam.md) feature is one of RaidProtect's main functionalities, and it can be frustrating if it’s not working. But rest assured, most of the time it’s nothing serious. 😇 
+
+- **If the anti-spam asks to stop the spam but does not sanction,** this is likely due to a lack of permissions. Remember, the bot must have Administrator permission and must be at the administrator level in the role hierarchy.
+
+- **Check the anti-spam configuration.** It’s quite simple, but some forget that they have ignored a channel.
+
+- **Check the spammer's permissions.** Administrators are ignored, so if you’re testing the anti-spam on your own server, it may not detect you.
+
+- **Is the spam long enough?** The bot generally only detects spam if it’s more than 5 messages. Don’t be too hasty.
+
+If spam is still not detected, [contact us on our support server](https://raidprotect.bot/discord) with a **screenshot of the issue**.
+
+## Users have access to the server without completing the captcha {#captcha}
+
+This problem is relatively common, but it depends on **your server configuration**. Let’s see how to fix it. 🏥 
+
+- **Do you have an auto role?** If you have set up a bot (other than RaidProtect) to give a role to newcomers on your server, this may interfere with the captcha. Replace it with the [RaidProtect autorole](../features/captcha.md#autorole). 
+
+- **Have you activated the captcha?** This is a completely optional feature that requires you to execute a command to enable it. Check the [dedicated captcha documentation page](../features/captcha.md#config) for more information.
+
+## Users can still talk when I lock a channel {#lock}
+
+The lock command seems magical, but it has its weaknesses. As [noted in this documentation](../features/channel-lock.md#lock), the command **only affects the @everyone role**. This means that if there is a role in the channel you want to lock that explicitly has permission to speak, they will still be able to do so. A picture is worth a thousand words, so here’s what that looks like in practice. 🔍 
+
+[Screenshot of channel lock configuration](../assets/lock-channel-messages-raidprotect.png)

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/guides/onboarding.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/guides/onboarding.md
@@ -1,0 +1,46 @@
+---
+title: Onboarding Process and Captcha
+---
+
+If the `#verification` channel is not visible by default for new members, this can prevent the Captcha system from working properly. Here’s how to fix this issue step by step.
+
+## 1️⃣ Check the channel permissions {#permissions}
+
+1. Open the `#verification` channel settings (right-click > **Edit Channel**).
+2. In the **Permissions** tab:
+   - Make sure `@everyone` **does not** have permission to view the channel.
+   - Ensure the `@Unverified` role **has** permission to **view the channel**, **read message history**, and **send messages**.
+
+## 2️⃣ Check the Welcome category {#default-category}
+
+1. Go to **Server Settings** > **Welcome**.
+2. In the **Default Channels** section, verify that the category containing `#verification` is checked as visible for new members.
+3. If needed, move `#verification` into a checked category.
+4. Save the changes.
+
+## 3️⃣ Refresh the configuration in RaidProtect {#refresh-config}
+
+1. Use the [`/settings`](../setup.md#settings) command and go to the **Captcha** tab.
+2. Click **Refresh** to force the configuration update.
+3. If the channel is now visible, the Captcha system will work correctly.
+
+## 4️⃣ Test with a test account {#test-account}
+
+To confirm everything is set up properly:
+
+1. Join the server with another Discord account.
+2. Check that the `#verification` channel is visible on arrival.
+3. Enter the Captcha code sent by RaidProtect.
+4. Once verified, the account should have access to the other channels.
+
+## 🛠️ Common issues and solutions {#common-issues}
+
+| Issue | Solution |
+|-------|----------|
+| 🔴 The `#verification` channel remains invisible | Check that it is in a **checked category** in Discord’s Welcome settings. |
+| 🚫 The `@Unverified` role cannot write | Grant it **send messages** permission in `#verification`. |
+| ❌ Captcha doesn’t work after changes | Click **“Refresh”** in `/settings > Captcha`. |
+
+---
+
+✅ By following these steps, your verification system will be fully operational to safely welcome members and effectively block bots or raids.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/guides/prefix.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/guides/prefix.md
@@ -1,0 +1,30 @@
+---
+title: Using a prefix
+---
+
+## Disabled Prefix (Default) {#disabled}
+
+By default, RaidProtect uses only Slash commands (`/`) to interact with the bot. This ensures intuitive and consistent usage with Discord standards.
+
+## Activated Prefix (Optional) {#activated}
+
+If you prefer to use certain commands with a custom prefix, you can enable this option. The default prefix when activated is `?`, but it can be modified to suit your needs. Once activated, these commands can be used with the configured prefix: 
+- [`?raidmode`](../features/raid-mode.md)
+- [`?ban`](../features/moderation.md#ban)
+- [`?kick`](../features/moderation.md#kick)
+- [`?lock`](../features/channel-lock.md#lock)
+- [`?unlock`](../features/channel-lock.md#unlock)
+- [`?userinfo` | `?ui`](../features/utilities#userinfo)
+- [`?clear`](../features/utilities#clear)
+
+## 💬 How to Enable or Disable the Prefix {#config}
+
+1. Open the configuration menu by typing [`/settings`](../setup.md#settings).
+2. Access the "**Prefix**" option for commands.
+3. Enable or disable the prefix according to your preferences.
+If enabled, customize the prefix by entering the desired character or string.
+
+:::note
+Slash commands (`/`) remain available even if the prefix is activated.
+It is recommended to avoid prefixes already used by other bots to prevent command conflicts.
+:::

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/guides/report-violation-to-discord.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/guides/report-violation-to-discord.md
@@ -1,0 +1,35 @@
+---
+title: Report a violation to Discord
+---
+
+Have you encountered a malicious user on Discord? Report them so that they can be sanctioned.
+
+On Discord, some users may not have good intentions. If they display behavior that is particularly harmful to the community, it is advisable to **report it to Discord's Trust & Safety team**. If the violation is found to be valid, the user may face sanctions ranging from a warning to account deletion. 😖 
+
+## 🧐 What Types of Violations to Report? {#types-of-violations}
+
+Of course, not all types of violations are subject to account deletion. Punishable behaviors are described in **Discord's [Community Guidelines](https://discord.com/guidelines)** (as well as in the [Terms of Service](https://discord.com/terms), which is more legal jargon than clear instructions). The list of report types on the reporting page is a great summary for those hesitant to read extensively.
+
+In general, **harmful behaviors to the community** (spam, promotion of illegal content, etc.) or **serious harm to a user** (doxxing, harassment) should be reported.
+
+For less extreme behaviors, **prefer banning** (on a server) or [blocking](https://support.discordapp.com/hc/en-us/articles/217916488-Blocking-and-Privacy-Settings) (throughout Discord). If you are not a moderator on the server where the actions are happening, feel free to report it to the moderation team, who must take action.
+
+## 🕵️ Collecting Evidence {#recover-evidences}
+
+To make a report, you need to provide evidence. First, note that **screenshots are not useful**; they can be easily falsified. You will need at least one (or preferably several) message links.
+
+**These links are very easy to obtain**. On a message corresponding to the violation you wish to report, right-click > Copy Message Link (on desktop) or Long press > Share > Copy to Clipboard (on mobile).
+
+## 📪 Reporting the Violation to the _Trust & Safety_ Team {#report-to-tns}
+
+Filing a report is very easy and takes only a few minutes. First, go to the **dedicated form** by following the link **https://dis.gd/report**.
+
+[Screenshot of Discord report](../assets/discord-report.png)
+
+Depending on the type of report selected, **different information will be requested**. Enter the link to the message obtained in the previous step in the appropriate field (and possibly the others in the description). Don’t hesitate to be **as thorough as possible** and remember the basic rules of politeness. 😇 
+
+### 📨 Discord's Response {#discord-response}
+
+A few days after your report—generally within a week—you should receive **a response via email** from Discord. Note that you will not be able to know the sanctions taken (or not) against the reported user. 😒
+
+[Screenshot of Discord response](../assets/discord-reply.png)

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/language.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/language.md
@@ -1,0 +1,32 @@
+---
+title: Language
+---
+
+RaidProtect allows you to choose the language used by the bot to best suit your Discord community.
+
+:::note
+If your server is set as a community server (Discord setting), RaidProtect will by default use the language configured in the server's **community settings**.
+:::
+
+**Public Messages:** The configured language only affects public messages sent by RaidProtect in your server (logs, captcha messages, reports, etc.).
+
+**Ephemeral Messages:** These private or temporary messages remain displayed in the language of the user interacting with the bot.
+
+## 🌐 List of Supported Languages {#supported}
+
+- **French**
+- **English**
+
+## ⚙️ Changing the Bot's Language {#change}
+
+- Use the [`/settings` command](./setup.md#settings).
+- Select the “**Language**” button.
+- Choose the desired language.
+
+![Screenshot of language settings](./assets/rpBeta-settings-language.webp)
+
+Once the language is selected, the bot will automatically adapt all its messages, notifications, and commands to the chosen language for your server.
+
+:::info
+RaidProtect's language support is constantly evolving! [Suggest](https://suggestions.raidprotect.bot) languages you'd like to see on the bot or [vote](https://suggestions.raidprotect.bot) for proposed languages to have them added.
+:::

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/readme.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/readme.mdx
@@ -1,0 +1,50 @@
+---
+title: Read Me
+slug: /
+---
+
+import DocCard from '@theme/DocCard';
+
+This documentation aims to explain how RaidProtect works. Feel free to send us your feedback so we can improve it.
+Don't forget to [join our Discord server](https://raidprotect.bot/discord) to stay informed about the latest updates on the project. You can also contact our support team who will answer your questions about using the bot. 😄
+
+## 🚀 Getting Started with RaidProtect {#start}
+
+To start using RaidProtect, simply invite it to your server using the following link.
+
+<DocCard item={{ type: 'link', href: 'https://raidprotect.bot/invite', label: 'Invite RaidProtect' }} />
+<br />
+
+:::danger
+Warning, **copies of the bot** are circulating **using the name RaidProtect**, only invite it from our official website.
+:::
+
+### Requirements {#requirement}
+
+To ensure the proper functioning of RaidProtect:
+1. **Grant the Administrator permission** to RaidProtect. This allows it to automatically moderate all your channels.
+2. **Place its role at the same level as your server administrators**. The permission system does not allow RaidProtect to sanction users with a role above it.
+
+### Installation {#install}
+
+Once RaidProtect is added to your server, run the [`/setup`](./setup.md#install) command.
+
+<DocCard item={{ type: 'link', href: '/3.1.0/setup', docId: 'setup', label: 'Guided Installation' }} />
+<br />
+
+:::note
+For the less adventurous (or the more impatient), you can simply read the instructions of the [`/setup`](./setup.md#advanced) command which summarizes the main information of each feature.
+:::
+
+### Usage {#use}
+
+Check out the different sections of this documentation to discover all the features offered by RaidProtect.
+
+<DocCard item={{ type: 'link', href: '/3.1.0/language', docId: 'language', label: 'Available Languages' }} />
+<br />
+<DocCard item={{ type: 'category', href: '/3.1.0/features', label: 'Features', description: 'Documentation for each of our features.' }} />
+<br />
+<DocCard item={{ type: 'category', href: '/3.1.0/guides', label: 'Our Guides', description: 'Guides to help you the best way possible.' }} />
+<br />
+<DocCard item={{ type: 'category', href: '/3.1.0/useful-links', label: 'Useful Links', description: 'Various useful links for RaidProtect.' }} />
+<br />

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/setup.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/setup.md
@@ -1,0 +1,53 @@
+---
+title: Installation
+---
+
+RaidProtect simplifies server management with two powerful tools: the [`/setup`](#install) command for a step-by-step guided setup and the [`/settings`](#settings) command to adjust your settings at any time through a centralized menu. This installation guide explains how to use them effectively.
+
+## Guided Installation {#install}
+
+The `/setup` command is designed to help you configure RaidProtect quickly or through a detailed approach, depending on your needs. It offers two configuration modes: [recommended](#recommended) or [advanced](#advanced).
+
+### 🔧 Recommended Configuration {#recommended}
+
+Allows you to enable or disable core features at a glance using an interactive selection menu.
+
+1. Use the `/setup` command.
+2. Select the “**Recommended Configuration**” button.
+3. Enable or disable the desired features using the selection menu.
+
+The bot will then send you a summary of the activated features and the changes it will make to the server.
+
+### 🛠️ Advanced Configuration {#advanced}
+
+If you want to configure the bot more thoroughly, opt for the advanced configuration. The bot guides you step by step with clear explanations.
+
+1. Use the `/setup` command.
+2. Select the “**Advanced Configuration**” button.
+3. Each step introduces a feature, its purpose, and a recommended minimum configuration.
+4. Use the “**Previous**” and “**Next**” buttons to move forward or go back.
+
+At the end, a summary of the settings is displayed to confirm your choices.
+
+## Modifying the Configuration {#settings}
+
+The `/settings` command is the go-to command for managing your settings after installation. It allows you to view, adjust, or customize RaidProtect's features at any time, in a simple and fast way.
+
+### 🔍 Settings Menu {#menu}
+
+1. Type `/settings` in a channel where the bot is active.
+2. Easily navigate between different sections to find the settings you want to modify.
+3. Adjust the options: Each category presents a list of customizable options in the form of buttons or dropdown menus.
+
+![Settings Screenshot](./assets/rpBeta-settings.webp)
+
+### 🔄 Resetting a Setting {#reset}
+
+1. Navigate to the desired setting.
+2. Click on “**Reset**”.
+
+The bot will confirm the reset before applying the changes.
+
+:::info Configuration Issue?
+If you encounter a problem, check the [Malfunctions](./guides/malfunctions) section or join our [support server](https://raidprotect.bot/discord) for assistance.
+:::

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/useful-links/index.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/useful-links/index.mdx
@@ -1,0 +1,9 @@
+---
+title: Useful links
+---
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1.json
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1.json
@@ -1,0 +1,30 @@
+{
+  "version.label": {
+    "message": "Alt - 3.1.1",
+    "description": "The label for version 3.1.1"
+  },
+  "sidebar.sidebar.category.features": {
+    "message": "Funktionen",
+    "description": "The label for category features in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.guides": {
+    "message": "Anleitungen",
+    "description": "The label for category guides in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.useful-links": {
+    "message": "Nützliche Links",
+    "description": "The label for category useful-links in sidebar sidebar"
+  },
+  "sidebar.sidebar.link.invite": {
+    "message": "RaidProtect einladen",
+    "description": "The label for link invite in sidebar sidebar, linking to https://raidprotect.bot/invite"
+  },
+  "sidebar.sidebar.link.discord": {
+    "message": "Discord-Server",
+    "description": "The label for link discord in sidebar sidebar, linking to https://raidprotect.bot/discord"
+  },
+  "sidebar.sidebar.link.suggest": {
+    "message": "Funktion vorschlagen",
+    "description": "The label for link suggest in sidebar sidebar, linking to https://suggestions.raidprotect.bot"
+  }
+}

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/changelog.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/changelog.mdx
@@ -1,0 +1,103 @@
+---
+title: Changelog
+---
+
+import SuggestionLink from '@site/src/components/SuggestionLink';
+
+Discover the detailed list of changes made to RaidProtect.
+
+## 3.1.1 (21/05/2025) {#3-1-1}
+
+- New feature [Role Tag](./features/tag-role.md). <SuggestionLink id="512" />
+- New moderation command [`/timeout`](./features/moderation#timeout). <SuggestionLink id="52" />
+- Automatic tracking of updates in each server's general log room.
+- Performance and stability:
+  - Cleanup of persistent antispam states.
+  - Fixed memory leaks.
+  - Optimized database calls.
+  - Improved overall bot speed.
+
+## 3.1.0 (12/03/2025) {#3-1-0}
+
+- Added **Slash Commands**. <SuggestionLink id="463" />
+- [Internationalization](./language.md) (added English). <SuggestionLink id="109" />
+- New feature [`/report`](./features/reports.md). <SuggestionLink id="164" />
+- New configuration commands:
+  - [`/settings`](./setup.md#settings) as an interactive panel.
+  - [`/setup`](./setup.md#install) as an Onboarding process.
+- Advanced settings:
+  - Enable/disable each feature individually. <SuggestionLink id="356" />
+  - Choose the delay and number of attempts before expulsion by the [captcha](./features/captcha#config). <SuggestionLink id="363" />
+  - Option to select the verification channel for the [captcha](./features/captcha). <SuggestionLink id="385" />
+  - Ignore users/roles/categories in the [anti-spam](./features/anti-spam.md#ignore). <SuggestionLink id="362" />
+  - Choose the [prefix for hybrid commands](./guides/prefix.md). <SuggestionLink id="103" />
+  - Option to choose whether the [`/lock` command](./features/channel-lock.md) renames the locked channel with `🔒`.
+- Improved UX:
+  - Prefix displayed when pinging the bot + mention as a universal prefix. <SuggestionLink id="193" />
+  - Disabling the [captcha](./features/captcha) no longer deletes the associated role and channel. <SuggestionLink id="43" />
+  - Automatic detection of permission issues related to channels and roles. <SuggestionLink id="65" />
+  - Automatic visibility check of the verification channel in Discord's onboarding process.
+  - Standardized messages.
+- Improved bot performance and stability.
+
+## 3.0.0 (01/14/2023) {#3-0-0}
+
+- Complete rewrite aimed at preparing for future updates and stabilizing the bot.
+- Fixed all known bugs to date.
+- The [`?raidmode` command](./features/raid-mode.md) now uses the "Disable Invites" feature.
+- Automatic sending of a private message to the concerned member when a sanction is applied. <SuggestionLink id="426" />
+
+## 2.2.0 (04/13/2020) {#2-2-0}
+
+- Improved bot performance.
+- Significant changes to the project's internal architecture.
+
+## 2.1.3 (10/13/2019) {#2-1-3}
+
+- Removed the blacklist and associated commands.
+- Ability to ban any user by their ID, even if they are not in the affected server. <SuggestionLink id="113" /> <SuggestionLink id="148" />
+- Display of the ban reason in the response of the [`?ban` command](./features/moderation.md#ban).
+- The [`?raidmode` command](./features/raid-mode.md) now requires the permission to kick members.
+- Changed the kick duration if the captcha is not completed (5 min). <SuggestionLink id="129" />
+- Various internal improvements.
+
+## 2.1.2 (04/17/2019) {#2-1-2}
+
+- Added the [`?userinfo` command](./features/utilities.md#userinfo). <SuggestionLink id="29" />
+- ~~Added the `?lockall` and `?unlockall` commands~~ (Feature removed).
+- Added the [`?kick`](./features/moderation.md#kick) and [`?ban`](./features/moderation.md#ban) commands.
+- Added [min-age to the captcha](./features/captcha.md#minage) (ability to set a minimum account age to access the server).
+- Option to configure automatic deletion of command invocation messages. <SuggestionLink id="26" />
+- The logs channel is automatically recreated if deleted.
+- Overhauled database connection.
+- Bug fixes and various improvements.
+
+## 2.1.1 (02/21/2019) {#2-1-1}
+
+- Removed `?settings captcha` (replaced by `?captcha`).
+- Added the ability to set a [logs channel](./features/captcha.md#logs) for the captcha.
+- Added an [autorole](./features/captcha.md#autorole) compatible with the captcha.
+- Simplified the [captcha](./features/captcha.md) (5/6 correct letters required).
+- Other minor changes.
+
+## 2.1.0 (02/16/2019) {#2-1-0}
+
+- Added captcha (`?settings captcha`). <SuggestionLink id="11" />
+- Added anti-spam security level (`?settings spamlevel`). <SuggestionLink id="25" />
+- Added the `?about` and `?invite` commands.
+- Added the [`?clear` command](./features/utilities.md#clear).
+- Various changes and bug fixes.
+
+## 2.0.1 (02/04/2019) {#2-0-1}
+
+- Rewrote the help (`?help`).
+- Fixed bugs in [`?lock`](./features/channel-lock.md#lock) and [`?unlock`](./features/channel-lock.md#unlock).
+
+## 2.0.0 (01/26/2019) {#2-0-0}
+
+- Added [anti-spam](./features/anti-spam.md).
+- Added [automatic raid mode](./features/raid-mode.md#config).
+- Added the logs channel.
+- Added bot configuration.
+- Added [channel locking](./features/channel-lock.md).
+- Numerous various changes.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/features/anti-spam.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/features/anti-spam.md
@@ -1,0 +1,44 @@
+---
+title: Anti-spam
+---
+
+RaidProtect's Anti-spam is a powerful tool to prevent spam on your Discord server. Thanks to its automatic detection system, it handles issues on its own without requiring your intervention.
+
+## ❓ How the Anti-spam Works {#working}
+
+RaidProtect's anti-spam detects and automatically blocks suspicious behavior. It distinguishes between two types of spam.
+- **Heavy spam:** Messages containing invitation links, mass mentions, or images. This type of spam is often used during raids.
+- **Light spam:** Messages sent frequently but less intrusive.
+
+RaidProtect's anti-spam acts in two ways.
+- **Sanctions:** Automatic kicking or banning of spammers.
+- **Notifications:** Sends messages to the log channel to report blocked spam with an overview of detected actions.
+
+## 🛡️ Configuring the Anti-spam {#config}
+
+RaidProtect offers three security levels to meet your server's needs.
+- 🔴 **High:** Sanctions all spam, including heavy spam in ignored channels.
+- 🟠 **Medium:** Sanctions all spam but respects ignored channels.
+- 🟢 **Low:** Sanctions only heavy spam.
+
+![Anti-spam settings screenshot](../assets/rp-settings-anti-spam.webp)
+
+### Changing the Security Level {#level}
+
+1. Use the [`/settings` command](../setup.md#settings).
+2. Click on the “**Anti-spam**” button.
+3. Select the desired anti-spam level from the first dropdown.
+
+### Managing Ignored Roles, Users, and Channels {#ignore}
+
+You can exclude certain channels, roles, or even users from anti-spam monitoring for added flexibility. 😉
+1. Use the [`/settings` command](../setup.md#settings).
+2. Click on the “**Anti-spam**” button.
+3. Select the different options to ignore in the dropdowns:
+- Channel(s) to ignore
+- Role(s) to ignore
+- Member(s) to ignore
+
+:::info
+Channels containing “**spam**” in their name are automatically ignored. Users with administrator permissions are completely ignored.
+:::

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/features/captcha.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/features/captcha.md
@@ -1,0 +1,66 @@
+---
+title: Captcha (Verification)
+---
+
+Prevent selfbots from accessing your Discord server and block raids with RaidProtect's captcha system.
+
+Captcha is one of RaidProtect's most popular features, though it remains entirely optional. It allows you to require each new user to complete a challenge by entering a code to verify that they are not a bot (selfbot).
+
+## ❓ How Captcha Works {#working}
+
+Captcha relies on a **@Unverified** role and a **#verification** channel. When a user joins your server:
+- The bot automatically assigns the **@Unverified** role to this user, limiting their access only to the **#verification** channel.
+- In this channel, the bot sends an image containing 6 uppercase letters. The user must transcribe the letters in the channel to prove they are human.
+- If the response is correct, the **@Unverified** role is removed, and the user gains normal access to the server. Otherwise, they are automatically kicked.
+- When captcha is enabled, RaidProtect automatically posts a message in the logs channel, indicating the account creation date of each new user.
+- RaidProtect automatically detects permission issues (channel and role) as well as the default visibility of the channel during Discord's onboarding process.
+
+:::info
+**Time Limit and Attempts:** Users have **1 to 10 minutes** to complete captcha (**5 minutes by default**) and **1 to 3 attempts** (**2 attempts by default**). If they exceed these limits, they are automatically kicked from the server.
+:::
+:::warning
+**Permission Management:** The permissions for the **@Unverified** role are automatically configured by RaidProtect. You can rename the role and the channel, but do not delete them.
+:::
+
+## 🚪 Captcha Configuration {#config}
+
+Setting up captcha is quick and easy.
+
+1. Run the [`/settings` command](../setup.md#settings).
+2. Click the "**Captcha**" button.
+3. Choose the channel where captchas will be conducted or use the "**Create one for me**" button.
+4. The **@Unverified** role is automatically created and configured.
+5. Configure the allowed number of attempts (between **1 and 3**) and the maximum resolution time (between **1 and 10 minutes**).
+
+![Captcha settings screenshot](../assets/rp-settings-captcha.webp)
+
+## ✨ Additional Features {#additional-features}
+
+To adapt to your server's needs, RaidProtect's captcha offers customizable options.
+
+### Separate Logs {#logs}
+
+If your server is popular, captcha-related logs may clutter your main logs channel. You can move them to another channel.
+
+1. Run the [`/settings` command](../setup.md#settings).
+2. Click the "**Logs**" button.
+3. Select "**Captcha**".
+4. Choose the channel where captcha logs will be stored or use the "**Create one for me**" button.
+
+### Auto Role {#autorole}
+
+If you use an automatic role (autorole) system other than RaidProtect, it may interfere with captcha. Replace your existing autorole with RaidProtect's.
+
+1. Run the [`/settings` command](../setup.md#settings).
+2. Click the "**Captcha**" button.
+3. Select "**Auto Role**".
+4. Choose the role that will be assigned to members who successfully complete captcha.
+
+### Minimum Account Age {#minage}
+
+To enhance security, you can require a minimum account age for new Discord members.
+
+1. Run the [`/settings` command](../setup.md#settings).
+2. Click the "**Captcha**" button.
+3. Press the "**Minimum Age**" button.
+4. Select the desired value from the dropdown menu or choose a custom value expressed in date format (m/h/d/y).

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/features/channel-lock.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/features/channel-lock.md
@@ -1,0 +1,32 @@
+---
+title: Channel locking
+---
+
+Sometimes it is necessary to temporarily lock a channel to prevent users from sending messages. With the lock command, this becomes a breeze!
+
+## 🔒 Lock a Channel {#lock}
+
+Use the command: ```/lock```
+
+This will remove the speaking permission from the **@everyone** role in the channel, preventing all users from posting in that channel.
+
+## 🔓 Unlock a Channel {#unlock}
+
+Use the command: ```/unlock```
+
+This will add the speaking permission back to the **@everyone** role in the channel, allowing all users to post in that channel.
+
+:::warning
+For the lock command to work properly, you must ensure that no roles have explicit permission to speak in that channel. Otherwise, members with those roles will still be able to chat.
+:::
+:::info
+The `lock` and `unlock` commands are [usable by prefix](../guides/prefix.md).
+:::
+
+## ✏️ Configuring the Lock Icon {#config}
+
+By default, this feature is disabled. However, you can choose whether locked channels should be renamed with a lock emoji (🔒) added in front of their name.
+
+To enable/disable the lock icon in front of the names of locked channels:  
+1. Use the [command `/settings`](../setup.md#settings).
+2. Click on the **Lock Icon on Locked Channels** button. This button acts as a toggle; a simple click is enough to enable or disable the option.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/features/index.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/features/index.mdx
@@ -1,0 +1,9 @@
+---
+title: Features
+---
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/features/moderation.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/features/moderation.md
@@ -1,0 +1,33 @@
+---
+title: Moderation
+---
+
+To facilitate the work of your moderators, RaidProtect integrates very useful moderation commands that allow you to interact directly with Discord's native features, such as **banning** and **kicking** users.
+
+In addition to these actions, RaidProtect sends direct messages to the sanctioned user to explain the reason for their sanction, and this is also recorded in the server logs for your reference.
+
+:::info
+Moderation commands are [usable by prefix](../guides/prefix.md).
+:::
+
+## 🔨 Ban a User {#ban}
+
+Use the command: ```/ban [@user] [reason]```
+
+Replace `[@user]` with the desired mention or ID and `[reason]` with the reason for the sanction.
+
+:::tip
+You can ban a user using their [Discord ID](https://dfr.gg/wiki/interface/mode-developpeur), even if they are not currently online or present on your server.
+:::
+
+## 👢 Kick a User {#kick}
+
+Use the command: ```/kick [@user] [reason]```
+
+Replace `[@user]` with the desired mention or ID and `[reason]` with the reason for the sanction.
+
+## ⏳ Timeout a User {#timeout}
+
+Use the command: ```/timeout [@user] [duration] [reason]```
+
+Replace `[@user]` with the desired mention or ID, `[duration]` with the timeout length, up to a maximum of 28 days (e.g. `10m`, `1h`, `1d`), and `[reason]` with the reason for the sanction.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/features/raid-mode.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/features/raid-mode.md
@@ -1,0 +1,46 @@
+---
+title: Raid mode
+---
+
+Raid mode is an emergency feature designed to instantly block all new users attempting to join your server. It is radical but effective in preventing mass raids. With RaidProtect's raid mode, you have an effective shield against massive attacks on your server. 🌟
+
+## ❓ How Raid Mode Works {#working}
+
+RaidProtect automatically activates raid mode if a large number of users join your server in a short period. By default, raid mode activates if more than 10 users join your server in less than 10 seconds. When raid mode is activated, no users can join the server. They are blocked at the invitation level.
+
+:::warning
+Discord’s Community features are essential for Raid mode to function properly. [Follow our guide to verify that Community is enabled on your server.](../guides/community.md)
+:::
+
+### Activation {#enable}
+
+- To manually activate this mode, a user with kick permissions must execute the command `/raidmode`.
+- A message will be automatically posted in the logs channel to indicate activation.
+
+### Deactivation {#disable}
+
+Raid mode does not deactivate automatically. Be sure to turn it off with the same command when the threat has passed. 😇
+
+:::info
+The `raidmode` command is [usable with a prefix](../guides/prefix.md).
+:::
+
+## 🚨 Configuring Automatic Raid Mode {#config}
+
+If your server frequently hosts many new members simultaneously, it is wise to adjust this threshold to avoid false positives.
+
+[Screenshot of automatic raid mode](../assets/rp-settings-raid-mode.webp)
+
+:::note
+We recommend entering a value between 10 and 20 members in 10 seconds for good system efficiency.
+:::
+
+1. Use the [command `/settings`](../setup.md#settings).
+2. Click the “**Auto RaidMode**” button.
+3. Select the number of members who can join within 10 seconds.
+
+You can leave the default value (10) or adjust it to the desired value by clicking the “**Custom Value**” button.
+
+:::warning
+If raid mode activates automatically, remember to disable it once the threat has passed. Keep in mind, it does not turn off by itself. 😖
+:::

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/features/reports.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/features/reports.md
@@ -1,0 +1,61 @@
+---
+title: Reports
+---
+
+The RaidProtect reporting system allows your community to quickly report any problematic content or suspicious users. It operates in two different ways and can be configured to optimize the reporting management process.
+
+## ❓ How Reporting Works {#working}
+Members can report content through 3 main methods.
+
+1. **Right-click on a message**  
+A member can right-click on a message they believe violates the rules, select **`Applications`**, and then click on **`Report Message`**. A popup will appear, allowing the user to add an explanation.
+
+2. **Right-click on a profile**  
+Similarly, a member can right-click on a profile they find problematic, choose **`Applications`**, and then click on **`Report Member`**. A popup will then open to allow the user to provide additional details about the situation.
+
+3. **Slash Command**  
+Members can also report a message or user via the **`/report`** command in any server channel.
+
+Use the command: ```/report [@user] [reason]```
+
+Replace `[@user]` with the desired user and `[reason]` with the reason for the infraction.
+
+## 🚩 Configuring Reports {#config}
+
+Before the reporting system is fully operational, it is imperative to configure a **report channel** where all reports will be sent. You need to set up a log or notification channel to receive alerts regarding reports.
+
+[Report settings screenshot](../assets/rp-settings-reports.webp)
+
+### Setting Up the Channel {#config-channel}
+
+1. Use the [command `/settings`](../setup.md#settings).
+2. Select the **Reports** button.
+3. Click on the **Channel** button.
+4. Choose the desired channel (_e.g. #reports_).  
+If you do not have a suitable channel, you can opt to create one automatically using the **Create one for me** button.
+
+### Configuring the Notification Role {#config-role}
+
+1. Use the [command `/settings`](../setup.md#settings).
+2. Select the **Reports** button.
+3. Click on the **Role** button.
+4. Choose the desired role (_e.g. @Moderator or @Report Ping_).  
+If you do not have a suitable role, you can opt to create one automatically with the **Create one for me** button.
+
+:::warning
+The channel should be restricted to moderators and administrators to ensure proper management of reports.
+:::
+
+## Managing Reports {#manage}
+
+As a community moderator, you can choose to accept or reject a report.
+
+- **✅ Accept a report:** If the report is valid, click the “Accept” button under the alert. This button does not trigger any specific action but indicates to other moderators that you consider this report to be handled, fostering coordination and organization.
+
+- **👁️ View Context:** To view the reported message and see the context, click “View Message” under the alert.
+
+- **❌ Reject a report:** If the report is not legitimate, click the “Reject” button under the alert. Similar to the “Accept” button, no specific action is associated with this button; it merely informs other moderators of your decision.
+
+:::note
+Ensure that your moderators are well-trained in using this feature and encourage your active members to use it responsibly!
+:::

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/features/tag-role.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/features/tag-role.md
@@ -1,0 +1,28 @@
+---
+title: Tag Role
+---
+
+The Tag Role automatically assigns a role to members who add [your server’s tag](https://support.discord.com/hc/en-us/articles/31444248479639-Server-Tags) to their Discord profile. By assigning a role to these members, you acknowledge their commitment and encourage them to actively represent your server. It’s a simple yet effective way to strengthen collective identity while rewarding your community’s most loyal ambassadors.
+
+## ❓ How the Tag Role Works {#working}
+
+It’s simple. As soon as a member adds the server’s tag to their Discord profile, RaidProtect automatically assigns them a specific role.  
+If the member removes the tag, the role is removed.
+
+:::info
+If the Tag is not enabled or your server doesn’t yet have the feature, the Tag Role will have no effect.
+:::
+
+## 🎖️ Configuring the Tag Role {#config}
+
+Configuration takes just a few clicks:  
+1. Use the [command `/settings`](../setup.md#settings).  
+2. Click the “**Tag Role**” button.  
+3. Select an existing role via the selector or click “**Create one for me**”.  
+4. You can deselect the role at any time by clicking on the “**Reset**” button.
+
+[Tag Role settings screenshot](../assets/rp-settings-tag-role.webp)
+
+:::tip
+Members will receive the role the next time they update their profile (Username, Avatar, Banner, Roles, Tag…). You can [contact support](https://raidprotect.bot/discord) to request a full role sync if you have many members who currently have or previously had the Tag.
+:::

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/features/utilities.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/features/utilities.md
@@ -1,0 +1,28 @@
+---
+title: Utilities
+---
+
+Additional features to simplify the management of your server. 🔧
+
+In addition to core features like the captcha system and anti-raid protection, RaidProtect offers several secondary tools that can make managing your server even smoother.
+
+:::info
+Utility commands are [usable by prefix](../guides/prefix.md).
+:::
+
+## 👤 User Information {#userinfo}
+
+The command `/userinfo` allows you to obtain detailed information about a user, such as their **Discord account creation date** and the **date they joined** your server (if they are a member).
+
+Use the command: ```/userinfo [@user]```
+
+Replace `[@user]` with the desired mention or ID.
+
+## 🧹 Clear a Group of Messages {#clear}
+
+The command `/clear` allows you to quickly delete a certain number of messages in a text channel. You can specify a user to delete only their messages.
+
+Use the command: ```/clear [number] (@user)```
+
+- Replace `[number]` with the number of messages you wish to delete (maximum 100).
+- Add `(@user)` using the mention or ID to target only their messages in the channel.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/guides/community.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/guides/community.md
@@ -1,0 +1,37 @@
+---
+title: Enable Community
+---
+
+Enabling the Community feature unlocks several advanced security settings essential for the proper functioning of some RaidProtect features like **DM Lock** or **Raid Mode**.
+
+## 🚦 Requirements {#requirement}
+
+- You must be an administrator of the Discord server.
+
+## 🚩 Enable Community Features {#steps}
+
+1. **Open your server settings**
+   - Click on the server name at the top left > “Server Settings”.
+
+2. **Go to the “Community” section**
+   - In the sidebar, navigate to the **Enable Community** tab and click **Get Started**.
+
+:::note
+If Community is already enabled on your server, the section will be called **Community Overview**.
+:::
+
+3. **Follow the setup wizard**
+   - Enable email verification for all members.
+   - Enable the explicit content filter.
+   - Set up a rules channel and an updates channel.
+   - Accept the Community Server guidelines.
+
+4. **Complete the setup**
+   - Click “Finish Setup”. The “Community” badge will appear on your server once activation is complete.
+
+![Discord Community activation screenshot](../assets/rp-enable-community.webp)
+
+## 💡 Use DM Lock & Raid Mode modules after activation {#use}
+
+- Run the [`/settings`](../setup.md#settings) command to open the RaidProtect configuration menu.
+- Enable or disable the desired modules (DM Lock, Raid Mode, etc.) from the interactive menu.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/guides/index.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/guides/index.mdx
@@ -1,0 +1,9 @@
+---
+title: Guides
+---
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/guides/malfunctions.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/guides/malfunctions.md
@@ -1,0 +1,61 @@
+---
+title: Malfunctions
+---
+
+Having an issue with RaidProtect? The solution is likely here.
+
+Sometimes things don't work as expected. Here are the **most common problems** you may encounter, along with how to solve them. 🤗 
+
+If this page does not answer a problem you're experiencing, [**feel free to contact our support**](https://raidprotect.bot/discord) who will be happy to help you!
+
+## The bot shows an error when I run a command {#commands}
+
+If the command does not execute successfully, **RaidProtect may display an error** instead of the expected result. In most cases, there will be an indication in the message, but it may be a more generic message. Here’s how to resolve this issue in most cases. 🧐 
+
+- **Do what is indicated.** Some errors clearly explain the problem. If the bot asks you to do something, please do it.
+
+- **Check the command parameters.** The command might simply be misspelled; check the help on how to use it. Remember that brackets ([]) are not to be included.
+
+- **Check the bot's permissions.** The bot must have **Administrator** permission and be at the administrator level in the role hierarchy.
+
+- **Retry the command.** Sometimes the issue resolves itself for unknown reasons.
+
+If you continue to receive an error despite following these tips, [contact our support](https://raidprotect.bot/discord) so we can assist you. 🤝 
+
+## The bot's log channel didn't create itself {#logs}
+
+To notify you of the actions it takes, RaidProtect needs a log channel. This channel is created automatically when the bot first joins, but sometimes no channel is created. Here’s how to remedy this issue. ⚙️ 
+
+- **Ensure the bot is an Administrator.** For the bot to function properly, it must be given Administrator permission. If this is not done, go to the role settings and grant this permission to the RaidProtect role. You then just need to manually initialize the bot for everything to work (see below)!
+
+- **Check that the bot is properly initialized.** This is usually done automatically, but you can force this initialization with the [command `/setup`](../setup.md#install). The log channel should be created automatically.
+
+- **Manually set a channel.** If nothing works, don’t panic; you can manually choose the channel the bot will use for logs! Once a dedicated channel is created, execute the [command /settings](../setup.md#settings) and then select Logs.
+
+## A user spammed, but the bot did not sanction them {#anti-spam}
+
+The [anti-spam](../features/anti-spam.md) feature is one of RaidProtect's main functionalities, and it can be frustrating if it’s not working. But rest assured, most of the time it’s nothing serious. 😇 
+
+- **If the anti-spam asks to stop the spam but does not sanction,** this is likely due to a lack of permissions. Remember, the bot must have Administrator permission and must be at the administrator level in the role hierarchy.
+
+- **Check the anti-spam configuration.** It’s quite simple, but some forget that they have ignored a channel.
+
+- **Check the spammer's permissions.** Administrators are ignored, so if you’re testing the anti-spam on your own server, it may not detect you.
+
+- **Is the spam long enough?** The bot generally only detects spam if it’s more than 5 messages. Don’t be too hasty.
+
+If spam is still not detected, [contact us on our support server](https://raidprotect.bot/discord) with a **screenshot of the issue**.
+
+## Users have access to the server without completing the captcha {#captcha}
+
+This problem is relatively common, but it depends on **your server configuration**. Let’s see how to fix it. 🏥 
+
+- **Do you have an auto role?** If you have set up a bot (other than RaidProtect) to give a role to newcomers on your server, this may interfere with the captcha. Replace it with the [RaidProtect autorole](../features/captcha.md#autorole). 
+
+- **Have you activated the captcha?** This is a completely optional feature that requires you to execute a command to enable it. Check the [dedicated captcha documentation page](../features/captcha.md#config) for more information.
+
+## Users can still talk when I lock a channel {#lock}
+
+The lock command seems magical, but it has its weaknesses. As [noted in this documentation](../features/channel-lock.md#lock), the command **only affects the @everyone role**. This means that if there is a role in the channel you want to lock that explicitly has permission to speak, they will still be able to do so. A picture is worth a thousand words, so here’s what that looks like in practice. 🔍 
+
+[Screenshot of channel lock configuration](../assets/lock-channel-messages-raidprotect.png)

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/guides/onboarding.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/guides/onboarding.md
@@ -1,0 +1,46 @@
+---
+title: Onboarding Process and Captcha
+---
+
+If the `#verification` channel is not visible by default for new members, this can prevent the Captcha system from working properly. Here’s how to fix this issue step by step.
+
+## 1️⃣ Check the channel permissions {#permissions}
+
+1. Open the `#verification` channel settings (right-click > **Edit Channel**).
+2. In the **Permissions** tab:
+   - Make sure `@everyone` **does not** have permission to view the channel.
+   - Ensure the `@Unverified` role **has** permission to **view the channel**, **read message history**, and **send messages**.
+
+## 2️⃣ Check the Welcome category {#default-category}
+
+1. Go to **Server Settings** > **Welcome**.
+2. In the **Default Channels** section, verify that the category containing `#verification` is checked as visible for new members.
+3. If needed, move `#verification` into a checked category.
+4. Save the changes.
+
+## 3️⃣ Refresh the configuration in RaidProtect {#refresh-config}
+
+1. Use the [`/settings`](../setup.md#settings) command and go to the **Captcha** tab.
+2. Click **Refresh** to force the configuration update.
+3. If the channel is now visible, the Captcha system will work correctly.
+
+## 4️⃣ Test with a test account {#test-account}
+
+To confirm everything is set up properly:
+
+1. Join the server with another Discord account.
+2. Check that the `#verification` channel is visible on arrival.
+3. Enter the Captcha code sent by RaidProtect.
+4. Once verified, the account should have access to the other channels.
+
+## 🛠️ Common issues and solutions {#common-issues}
+
+| Issue | Solution |
+|-------|----------|
+| 🔴 The `#verification` channel remains invisible | Check that it is in a **checked category** in Discord’s Welcome settings. |
+| 🚫 The `@Unverified` role cannot write | Grant it **send messages** permission in `#verification`. |
+| ❌ Captcha doesn’t work after changes | Click **“Refresh”** in `/settings > Captcha`. |
+
+---
+
+✅ By following these steps, your verification system will be fully operational to safely welcome members and effectively block bots or raids.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/guides/prefix.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/guides/prefix.md
@@ -1,0 +1,32 @@
+---
+title: Using a prefix
+---
+
+## Disabled Prefix (Default) {#disabled}
+
+By default, RaidProtect uses only Slash commands (`/`) to interact with the bot. This ensures intuitive and consistent usage with Discord standards.
+
+## Activated Prefix (Optional) {#activated}
+
+If you prefer to use certain commands with a custom prefix, you can enable this option. The default prefix when activated is `?`, but it can be modified to suit your needs. Once activated, these commands can be used with the configured prefix: 
+- [`?raidmode`](../features/raid-mode.md)
+- [`?ban`](../features/moderation.md#ban)
+- [`?kick`](../features/moderation.md#kick)
+- [`?lock`](../features/channel-lock.md#lock)
+- [`?unlock`](../features/channel-lock.md#unlock)
+- [`?userinfo` | `?ui`](../features/utilities#userinfo)
+- [`?clear`](../features/utilities#clear)
+
+## 💬 How to Enable or Disable the Prefix {#config}
+
+1. Open the configuration menu by typing [`/settings`](../setup.md#settings).
+2. Access the "**Prefix**" option for commands.
+3. Enable or disable the prefix according to your preferences.
+If enabled, customize the prefix by entering the desired character or string.
+
+![Prefix settings screenshot](../assets/rp-settings-prefix.webp)
+
+:::note
+Slash commands (`/`) remain available even if the prefix is activated.
+It is recommended to avoid prefixes already used by other bots to prevent command conflicts.
+:::

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/guides/report-violation-to-discord.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/guides/report-violation-to-discord.md
@@ -1,0 +1,35 @@
+---
+title: Report a violation to Discord
+---
+
+Have you encountered a malicious user on Discord? Report them so that they can be sanctioned.
+
+On Discord, some users may not have good intentions. If they display behavior that is particularly harmful to the community, it is advisable to **report it to Discord's Trust & Safety team**. If the violation is found to be valid, the user may face sanctions ranging from a warning to account deletion. 😖 
+
+## 🧐 What Types of Violations to Report? {#types-of-violations}
+
+Of course, not all types of violations are subject to account deletion. Punishable behaviors are described in **Discord's [Community Guidelines](https://discord.com/guidelines)** (as well as in the [Terms of Service](https://discord.com/terms), which is more legal jargon than clear instructions). The list of report types on the reporting page is a great summary for those hesitant to read extensively.
+
+In general, **harmful behaviors to the community** (spam, promotion of illegal content, etc.) or **serious harm to a user** (doxxing, harassment) should be reported.
+
+For less extreme behaviors, **prefer banning** (on a server) or [blocking](https://support.discordapp.com/hc/en-us/articles/217916488-Blocking-and-Privacy-Settings) (throughout Discord). If you are not a moderator on the server where the actions are happening, feel free to report it to the moderation team, who must take action.
+
+## 🕵️ Collecting Evidence {#recover-evidences}
+
+To make a report, you need to provide evidence. First, note that **screenshots are not useful**; they can be easily falsified. You will need at least one (or preferably several) message links.
+
+**These links are very easy to obtain**. On a message corresponding to the violation you wish to report, right-click > Copy Message Link (on desktop) or Long press > Share > Copy to Clipboard (on mobile).
+
+## 📪 Reporting the Violation to the _Trust & Safety_ Team {#report-to-tns}
+
+Filing a report is very easy and takes only a few minutes. First, go to the **dedicated form** by following the link **https://dis.gd/report**.
+
+[Screenshot of Discord report](../assets/discord-report.png)
+
+Depending on the type of report selected, **different information will be requested**. Enter the link to the message obtained in the previous step in the appropriate field (and possibly the others in the description). Don’t hesitate to be **as thorough as possible** and remember the basic rules of politeness. 😇 
+
+### 📨 Discord's Response {#discord-response}
+
+A few days after your report—generally within a week—you should receive **a response via email** from Discord. Note that you will not be able to know the sanctions taken (or not) against the reported user. 😒
+
+[Screenshot of Discord response](../assets/discord-reply.png)

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/language.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/language.md
@@ -1,0 +1,32 @@
+---
+title: Language
+---
+
+RaidProtect allows you to choose the language used by the bot to best suit your Discord community.
+
+:::note
+If your server is set as a community server (Discord setting), RaidProtect will by default use the language configured in the server's **community settings**.
+:::
+
+**Public Messages:** The configured language only affects public messages sent by RaidProtect in your server (logs, captcha messages, reports, etc.).
+
+**Ephemeral Messages:** These private or temporary messages remain displayed in the language of the user interacting with the bot.
+
+## 🌐 List of Supported Languages {#supported}
+
+- **French**
+- **English**
+
+## ⚙️ Changing the Bot's Language {#change}
+
+- Use the [`/settings` command](./setup.md#settings).
+- Select the “**Language**” button.
+- Choose the desired language.
+
+![Screenshot of language settings](./assets/rp-settings-language.webp)
+
+Once the language is selected, the bot will automatically adapt all its messages, notifications, and commands to the chosen language for your server.
+
+:::info
+RaidProtect's language support is constantly evolving! [Suggest](https://suggestions.raidprotect.bot) languages you'd like to see on the bot or [vote](https://suggestions.raidprotect.bot) for proposed languages to have them added.
+:::

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/readme.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/readme.mdx
@@ -1,0 +1,50 @@
+---
+title: Read Me
+slug: /
+---
+
+import DocCard from '@theme/DocCard';
+
+This documentation aims to explain how RaidProtect works. Feel free to send us your feedback so we can improve it.
+Don't forget to [join our Discord server](https://raidprotect.bot/discord) to stay informed about the latest updates on the project. You can also contact our support team who will answer your questions about using the bot. 😄
+
+## 🚀 Getting Started with RaidProtect {#start}
+
+To start using RaidProtect, simply invite it to your server using the following link.
+
+<DocCard item={{ type: 'link', href: 'https://raidprotect.bot/invite', label: 'Invite RaidProtect' }} />
+<br />
+
+:::danger
+Warning, **copies of the bot** are circulating **using the name RaidProtect**, only invite it from our official website.
+:::
+
+### Requirements {#requirement}
+
+To ensure the proper functioning of RaidProtect:
+1. **Grant the Administrator permission** to RaidProtect. This allows it to automatically moderate all your channels.
+2. **Place its role at the same level as your server administrators**. The permission system does not allow RaidProtect to sanction users with a role above it.
+
+### Installation {#install}
+
+Once RaidProtect is added to your server, run the [`/setup`](./setup.md#install) command.
+
+<DocCard item={{ type: 'link', href: '/3.1.1/setup', docId: 'setup', label: 'Guided Installation' }} />
+<br />
+
+:::note
+For the less adventurous (or the more impatient), you can simply read the instructions of the [`/setup`](./setup.md#advanced) command which summarizes the main information of each feature.
+:::
+
+### Usage {#use}
+
+Check out the different sections of this documentation to discover all the features offered by RaidProtect.
+
+<DocCard item={{ type: 'link', href: '/3.1.1/language', docId: 'language', label: 'Available Languages' }} />
+<br />
+<DocCard item={{ type: 'category', href: '/3.1.1/features', label: 'Features', description: 'Documentation for each of our features.' }} />
+<br />
+<DocCard item={{ type: 'category', href: '/3.1.1/guides', label: 'Our Guides', description: 'Guides to help you the best way possible.' }} />
+<br />
+<DocCard item={{ type: 'category', href: '/3.1.1/useful-links', label: 'Useful Links', description: 'Various useful links for RaidProtect.' }} />
+<br />

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/setup.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/setup.md
@@ -1,0 +1,58 @@
+---
+title: Installation
+---
+
+RaidProtect simplifies server management with two powerful tools: the [`/setup`](#install) command for a step-by-step guided setup and the [`/settings`](#settings) command to adjust your settings at any time through a centralized menu. This installation guide explains how to use them effectively.
+
+## Guided Installation {#install}
+
+The `/setup` command is designed to help you configure RaidProtect quickly or through a detailed approach, depending on your needs. It offers two configuration modes: [recommended](#recommended) or [advanced](#advanced).
+
+### 🔧 Recommended Configuration {#recommended}
+
+Allows you to enable or disable core features at a glance using an interactive selection menu.
+
+1. Use the `/setup` command.
+2. Select the “**Recommended Configuration**” button.
+3. Enable or disable the desired features using the selection menu.
+
+The bot will then send you a summary of the activated features and the changes it will make to the server.
+
+![Recommended configuration screenshot](./assets/rp-setup.webp)
+
+<!--
+### 🛠️ Advanced Configuration {#advanced}
+
+If you want to configure the bot more thoroughly, opt for the advanced configuration. The bot guides you step by step with clear explanations.
+
+1. Use the `/setup` command.
+2. Select the “**Advanced Configuration**” button.
+3. Each step introduces a feature, its purpose, and a recommended minimum configuration.
+4. Use the “**Previous**” and “**Next**” buttons to move forward or go back.
+
+At the end, a summary of the settings is displayed to confirm your choices.
+-->
+## Modifying the Configuration {#settings}
+
+The `/settings` command is the go-to command for managing your settings after installation. It allows you to view, adjust, or customize RaidProtect's features at any time, in a simple and fast way.
+
+### 🔍 Settings Menu {#menu}
+
+1. Type `/settings` in a channel where the bot is active.
+2. Easily navigate between different sections to find the settings you want to modify.
+3. Adjust the options: Each category presents a list of customizable options in the form of buttons or dropdown menus.
+
+![Settings screenshot](./assets/rp-settings.webp)
+
+### 🔄 Resetting a Setting {#reset}
+
+1. Navigate to the desired setting.
+2. Click on “**Reset**”.
+
+![Reset button screenshot](./assets/rp-button-reset.webp)
+
+The bot will confirm the reset before applying the changes.
+
+:::info Configuration Issue?
+If you encounter a problem, check the [Malfunctions](./guides/malfunctions) section or join our [support server](https://raidprotect.bot/discord) for assistance.
+:::

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/useful-links/index.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/useful-links/index.mdx
@@ -1,0 +1,9 @@
+---
+title: Useful links
+---
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0.json
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0.json
@@ -1,0 +1,34 @@
+{
+  "version.label": {
+    "message": "Stabil - 3.2.0",
+    "description": "The label for version current"
+  },
+  "sidebar.sidebar.category.features": {
+    "message": "Funktionen",
+    "description": "The label for category features in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.guides": {
+    "message": "Anleitungen",
+    "description": "The label for category guides in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.useful-links": {
+    "message": "Nützliche Links",
+    "description": "The label for category useful-links in sidebar sidebar"
+  },
+  "sidebar.sidebar.link.invite": {
+    "message": "RaidProtect einladen",
+    "description": "The label for link invite in sidebar sidebar, linking to https://raidprotect.bot/invite"
+  },
+  "sidebar.sidebar.link.discord": {
+    "message": "Discord-Server",
+    "description": "The label for link discord in sidebar sidebar, linking to https://raidprotect.bot/discord"
+  },
+  "sidebar.sidebar.link.suggest": {
+    "message": "Funktion vorschlagen",
+    "description": "The label for link suggest in sidebar sidebar, linking to https://suggestions.raidprotect.bot"
+  },
+  "sidebar.sidebar.link.report": {
+    "message": "Einen Verstoß an Discord melden",
+    "description": "The label for link report in sidebar sidebar, linking to https://discord.com/safety/360044103651-reporting-abusive-behavior-to-discord"
+  }
+}

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/changelog.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/changelog.mdx
@@ -1,0 +1,126 @@
+---
+title: Changelog
+---
+
+import SuggestionLink from '@site/src/components/SuggestionLink';
+
+Discover the detailed list of changes made to RaidProtect.
+
+## 3.2.0 (10/07/2025) {#3-2-0}
+
+- New feature [DM Lock](./features/dm-lock.mdx).
+- Choice of [sanctions](./features/anti-spam.mdx#triggers) applied by anti-spam. <SuggestionLink id="85" />
+- New [anti-spam logs](./features/anti-spam.mdx#logs) (more visibility on detections).
+- Activation of a [minimum account age](./features/raid-mode.md#minage) without captcha. <SuggestionLink id="314" />
+- New [command /bypass minage](./features/raid-mode.md#bypass-minage) to accept a user who doesn’t meet the required account age. <SuggestionLink id="447" />
+- Complete overhaul of the [command `/userinfo`](./features/utilities.mdx#userinfo).
+- New logs for important bot configuration changes.
+- Fixes:
+  - Anti-spam now works in threads.
+  - The [command `/lock`](./features/channel-lock.md) now supports forum and media channels, and blocks threads with the channels.
+  - The [captcha](./features/captcha.md) no longer blocks new members when the bot does not have the necessary permissions.
+  - Fixed the bug with the [command `/clear`](./features/moderation.md#clear) when the bot lacked the necessary permissions in a channel.
+- Improved UI/UX:
+  - Clarification on the ability to type in the member, role, and channel select menus.
+  - Check for the presence of the `COMMUNITY` feature when configuring Auto Raid Mode.
+- Performance and stability:
+  - Revamped emoji management ([`@fca.gg/glyph` v1.0.0](https://github.com/FCAgreatgoals/glyph)).
+  - Reduced startup time and cluster monitoring (`@fca.gg/midway` v1.3.1).
+  - Better rate limit handling and reduced latency (`@fca.gg/iris` v1.1.4).
+  - Integrated Sentry for error tracking and improved dev support ([`@fca.gg/kino` v1.0.0](https://github.com/FCAgreatgoals/kino)).
+
+## 3.1.1 (21/05/2025) {#3-1-1}
+
+- New feature [Role Tag](./features/tag-role.md). <SuggestionLink id="512" />
+- New moderation command [`/timeout`](./features/moderation.md#timeout). <SuggestionLink id="52" />
+- Automatic tracking of updates in each server's general log room.
+- Performance and stability:
+  - Cleanup of persistent antispam states.
+  - Fixed memory leaks.
+  - Optimized database calls.
+  - Improved overall bot speed.
+
+## 3.1.0 (12/03/2025) {#3-1-0}
+
+- Added **Slash Commands**. <SuggestionLink id="463" />
+- [Internationalization](./language.md) (added English). <SuggestionLink id="109" />
+- New feature [`/report`](./features/reports.md). <SuggestionLink id="164" />
+- New configuration commands:
+  - [`/settings`](./setup.md#settings) as an interactive panel.
+  - [`/setup`](./setup.md#install) as an Onboarding process.
+- Advanced settings:
+  - Enable/disable each feature individually. <SuggestionLink id="356" />
+  - Choose the delay and number of attempts before expulsion by the [captcha](./features/captcha.md#config). <SuggestionLink id="363" />
+  - Option to select the verification channel for the [captcha](./features/captcha.md). <SuggestionLink id="385" />
+  - Ignore users/roles/categories in the [anti-spam](./features/anti-spam.mdx#ignore). <SuggestionLink id="362" />
+  - Choose the [prefix for hybrid commands](./guides/prefix.md). <SuggestionLink id="103" />
+  - Option to choose whether the [`/lock` command](./features/channel-lock.md) renames the locked channel with `🔒`.
+- Improved UX:
+  - Prefix displayed when pinging the bot + mention as a universal prefix. <SuggestionLink id="193" />
+  - Disabling the [captcha](./features/captcha.md) no longer deletes the associated role and channel. <SuggestionLink id="43" />
+  - Automatic detection of permission issues related to channels and roles. <SuggestionLink id="65" />
+  - Automatic visibility check of the verification channel in Discord's onboarding process.
+  - Standardized messages.
+- Improved bot performance and stability.
+
+## 3.0.0 (01/14/2023) {#3-0-0}
+
+- Complete rewrite aimed at preparing for future updates and stabilizing the bot.
+- Fixed all known bugs to date.
+- The [`?raidmode` command](./features/raid-mode.md) now uses the "Disable Invites" feature.
+- Automatic sending of a private message to the concerned member when a sanction is applied. <SuggestionLink id="426" />
+
+## 2.2.0 (04/13/2020) {#2-2-0}
+
+- Improved bot performance.
+- Significant changes to the project's internal architecture.
+
+## 2.1.3 (10/13/2019) {#2-1-3}
+
+- Removed the blacklist and associated commands.
+- Ability to ban any user by their ID, even if they are not in the affected server. <SuggestionLink id="113" /> <SuggestionLink id="148" />
+- Display of the ban reason in the response of the [`?ban` command](./features/moderation.md#ban).
+- The [`?raidmode` command](./features/raid-mode.md) now requires the permission to kick members.
+- Changed the kick duration if the captcha is not completed (5 min). <SuggestionLink id="129" />
+- Various internal improvements.
+
+## 2.1.2 (04/17/2019) {#2-1-2}
+
+- Added the [`?userinfo` command](./features/utilities.mdx#userinfo). <SuggestionLink id="29" />
+- ~~Added the `?lockall` and `?unlockall` commands~~ (Feature removed).
+- Added the [`?kick`](./features/moderation.md#kick) and [`?ban`](./features/moderation.md#ban) commands.
+- Added [min-age to the captcha](./features/raid-mode.md#minage) (ability to set a minimum account age to access the server).
+- Option to configure automatic deletion of command invocation messages. <SuggestionLink id="26" />
+- The logs channel is automatically recreated if deleted.
+- Overhauled database connection.
+- Bug fixes and various improvements.
+
+## 2.1.1 (02/21/2019) {#2-1-1}
+
+- Removed `?settings captcha` (replaced by `?captcha`).
+- Added the ability to set a [logs channel](./features/captcha.md#logs) for the captcha.
+- Added an [autorole](./features/captcha.md#autorole) compatible with the captcha.
+- Simplified the [captcha](./features/captcha.md) (5/6 correct letters required).
+- Other minor changes.
+
+## 2.1.0 (02/16/2019) {#2-1-0}
+
+- Added captcha (`?settings captcha`). <SuggestionLink id="11" />
+- Added anti-spam security level (`?settings spamlevel`). <SuggestionLink id="25" />
+- Added the `?about` and `?invite` commands.
+- Added the [`?clear` command](./features/moderation.md#clear).
+- Various changes and bug fixes.
+
+## 2.0.1 (02/04/2019) {#2-0-1}
+
+- Rewrote the help (`?help`).
+- Fixed bugs in [`?lock`](./features/channel-lock.md#lock) and [`?unlock`](./features/channel-lock.md#unlock).
+
+## 2.0.0 (01/26/2019) {#2-0-0}
+
+- Added [anti-spam](./features/anti-spam.mdx).
+- Added [automatic raid mode](./features/raid-mode.md#config).
+- Added the logs channel.
+- Added bot configuration.
+- Added [channel locking](./features/channel-lock.md).
+- Numerous various changes.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/features/anti-spam.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/features/anti-spam.mdx
@@ -1,0 +1,98 @@
+---
+title: Anti-spam
+---
+
+import SeparatedBox from '@site/src/components/SeparatedBox';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+RaidProtect's Anti-spam is a powerful tool to prevent spam on your Discord server. Thanks to its automatic detection system, it handles issues on its own without requiring your intervention.
+
+## ❓ How the Anti-spam Works {#working}
+
+RaidProtect's anti-spam detects and automatically blocks suspicious behavior. It distinguishes between two types of spam.
+- **Heavy spam:** Messages containing invitation links, mass mentions, or images. This type of spam is often used during raids.
+- **Light spam:** Messages sent frequently but less intrusive.
+
+RaidProtect's anti-spam acts in two ways.
+- **Sanctions:** Automatic kicking or banning of spammers.
+- **Notifications:** Sends messages to the log channel to report blocked spam with an overview of detected actions.
+
+## 🛡️ Configuring the Anti-spam {#config}
+
+RaidProtect offers three security levels to meet your server's needs.
+- 🔴 **High:** Sanctions all spam, including heavy spam in ignored channels.
+- 🟠 **Medium:** Sanctions all spam but respects ignored channels.
+- 🟢 **Low:** Sanctions only heavy spam.
+
+![Anti-spam settings screenshot](../assets/rp-settings-anti-spam.webp)
+
+### Changing the Security Level {#level}
+
+1. Use the [`/settings` command](../setup.md#settings).
+2. Click on the “**Anti-spam**” button.
+3. Select the desired anti-spam level from the first dropdown.
+
+### Managing Ignored Roles, Users, and Channels {#ignore}
+
+You can exclude certain channels, roles, or even users from anti-spam monitoring for added flexibility. 😉
+1. Use the [`/settings` command](../setup.md#settings).
+2. Click on the “**Anti-spam**” button.
+3. Select the different options to ignore in the dropdowns:
+- Channel(s) to ignore
+- Role(s) to ignore
+- Member(s) to ignore
+
+:::info
+Channels containing “**spam**” in their name are automatically ignored. Users with administrator permissions are completely ignored.
+:::
+
+### Configure sanctions by trigger {#triggers}
+
+You can customize the sanctions applied depending on the type of spam detected. This allows for a response adapted to the severity of the violation.
+
+1. Use the [ `/settings` command](../setup.md#settings).
+2. Click on the “**Anti-spam**” button.
+3. Go to the “**Sanctions**” tab.
+4. For each trigger, select a specific sanction. You can modify these values using the dropdown menus:
+- **Select a trigger**: choose the type of spam to configure.
+- **Select a sanction**: choose the corresponding sanction.
+
+#### Types of Sanctions and Triggers {#sanctions}
+
+Here are the different **available sanctions** as well as the **triggers** that RaidProtect can detect, along with the **default timeout duration** if applicable:
+
+- **Warn**: Sends a warning to the member.
+- **Kick**: Removes the member from the server.
+- **Timeout**: Mutes the member for a set duration.
+- **Softban**: Bans and immediately unbans the member, deleting their messages.
+- **Ban**: Permanently bans the member.
+
+| Trigger                                | Description                                             | Timeout Duration   |
+|----------------------------------------|---------------------------------------------------------|--------------------|
+| Spam                                   | Repeated message sending                                | 1 minute           |
+| Spam with selfbot                      | Use of selfbots to spam                                 | 1 hour             |
+| Mention spam                           | Repeated mass mentions                                  | 30 minutes         |
+| Link spam                              | Mass sending of links                                   | 24 hours           |
+| Duplicate or heavy spam                | Copied messages or excessive spam                       | 24 hours           |
+
+![Screenshot of anti-spam sanctions](../assets/rp-settings-anti-spam-sanctions.webp)
+
+## 📑 Anti-spam Logs {#logs}
+
+Detailed logs are generated with all messages deleted by the anti-spam. You can simply download or expand the content.
+
+<SeparatedBox>
+<Tabs>
+  <TabItem value="animator" label="Collapsed" default>
+
+![Screenshot of anti-spam logs](../assets/rp-logs-anti-spam.webp)
+
+  </TabItem>
+  <TabItem value="moderator" label="Expanded">
+
+![Screenshot of expanded anti-spam logs](../assets/rp-logs-anti-spam-expand.webp)
+
+  </TabItem>
+</Tabs>
+</SeparatedBox>

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/features/captcha.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/features/captcha.md
@@ -1,0 +1,57 @@
+---
+title: Captcha (Verification)
+---
+
+Prevent selfbots from accessing your Discord server and block raids with RaidProtect's captcha system.
+
+Captcha is one of RaidProtect's most popular features, though it remains entirely optional. It allows you to require each new user to complete a challenge by entering a code to verify that they are not a bot (selfbot).
+
+## ❓ How Captcha Works {#working}
+
+Captcha relies on a **@Unverified** role and a **#verification** channel. When a user joins your server:
+- The bot automatically assigns the **@Unverified** role to this user, limiting their access only to the **#verification** channel.
+- In this channel, the bot sends an image containing 6 uppercase letters. The user must transcribe the letters in the channel to prove they are human.
+- If the response is correct, the **@Unverified** role is removed, and the user gains normal access to the server. Otherwise, they are automatically kicked.
+- When captcha is enabled, RaidProtect automatically posts a message in the logs channel, indicating the account creation date of each new user.
+- RaidProtect automatically detects permission issues (channel and role) as well as the default visibility of the channel during Discord's onboarding process.
+
+:::info
+**Time Limit and Attempts:** Users have **1 to 10 minutes** to complete captcha (**5 minutes by default**) and **1 to 3 attempts** (**2 attempts by default**). If they exceed these limits, they are automatically kicked from the server.
+:::
+:::warning
+**Permission Management:** The permissions for the **@Unverified** role are automatically configured by RaidProtect. You can rename the role and the channel, but do not delete them.
+:::
+
+## 🚪 Captcha Configuration {#config}
+
+Setting up captcha is quick and easy.
+
+1. Run the [`/settings` command](../setup.md#settings).
+2. Click the "**Captcha**" button.
+3. Choose the channel where captchas will be conducted or use the "**Create one for me**" button.
+4. The **@Unverified** role is automatically created and configured.
+5. Configure the allowed number of attempts (between **1 and 3**) and the maximum resolution time (between **1 and 10 minutes**).
+
+![Captcha settings screenshot](../assets/rp-settings-captcha.webp)
+
+## ✨ Additional Features {#additional-features}
+
+To adapt to your server's needs, RaidProtect's captcha offers customizable options.
+
+### Separate Logs {#logs}
+
+If your server is popular, captcha-related logs may clutter your main logs channel. You can move them to another channel.
+
+1. Run the [`/settings` command](../setup.md#settings).
+2. Click the "**Logs**" button.
+3. Select "**Captcha**".
+4. Choose the channel where captcha logs will be stored or use the "**Create one for me**" button.
+
+### Auto Role {#autorole}
+
+If you use an automatic role (autorole) system other than RaidProtect, it may interfere with captcha. Replace your existing autorole with RaidProtect's.
+
+1. Run the [`/settings` command](../setup.md#settings).
+2. Click the "**Captcha**" button.
+3. Select "**Auto Role**".
+4. Choose the role that will be assigned to members who successfully complete captcha.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/features/channel-lock.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/features/channel-lock.md
@@ -1,0 +1,32 @@
+---
+title: Channel locking
+---
+
+Sometimes it is necessary to temporarily lock a channel to prevent users from sending messages. With the lock command, this becomes a breeze!
+
+## 🔒 Lock a Channel {#lock}
+
+Use the command: ```/lock```
+
+This will remove the speaking permission from the **@everyone** role in the channel, preventing all users from posting in that channel.
+
+## 🔓 Unlock a Channel {#unlock}
+
+Use the command: ```/unlock```
+
+This will add the speaking permission back to the **@everyone** role in the channel, allowing all users to post in that channel.
+
+:::warning
+For the lock command to work properly, you must ensure that no roles have explicit permission to speak in that channel. Otherwise, members with those roles will still be able to chat.
+:::
+:::info
+The `lock` and `unlock` commands are [usable by prefix](../guides/prefix.md).
+:::
+
+## ✏️ Configuring the Lock Icon {#config}
+
+By default, this feature is disabled. However, you can choose whether locked channels should be renamed with a lock emoji (🔒) added in front of their name.
+
+To enable/disable the lock icon in front of the names of locked channels:  
+1. Use the [command `/settings`](../setup.md#settings).
+2. Click on the **Lock Icon on Locked Channels** button. This button acts as a toggle; a simple click is enough to enable or disable the option.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/features/dm-lock.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/features/dm-lock.mdx
@@ -1,0 +1,69 @@
+---
+title: DM Lock
+---
+
+import SeparatedBox from '@site/src/components/SeparatedBox';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+The **DM Lock** feature of RaidProtect permanently closes access to server-originated direct messages (DMs), surpassing Discord’s native limitation, which only allows this block for 24 hours via the "Pause DMs" security action.
+
+## 🚦 Use cases and recommendations {#recommendations}
+
+- **Servers exposed to spam or harassment:** DM Lock is especially recommended for public or high-traffic communities where the risk of DM abuse is higher.
+- **Temporary events or sensitive periods:** During launches, major announcements, or periods of heavy activity (e.g. contests, promotions), enabling DM Lock helps prevent phishing or scam attempts.
+- **Communities with a young audience:** For servers with many minors, restricting DMs can enhance safety and help prevent inappropriate behavior.
+- **Continuous protection:** Thanks to automation, there’s no vulnerability window from forgetting to renew the block manually.
+
+## ❓ How DM Lock works {#working}
+
+The RaidProtect bot regularly checks the server’s DM blocking setting and, if needed, automatically re-enables it to prevent any vulnerability window between manual renewals. This task runs transparently for server admins and members.
+
+:::info
+It remains possible to send and receive messages with:
+- friends
+- bots
+- staff
+:::
+:::warning
+Discord’s community features are essential for DM Lock to function properly. [Follow our guide to check if Community is enabled on your server.](../guides/community.md)
+:::
+
+## 🚩 Configuring DM Lock {#config}
+
+1. Run the [ `/settings` command](../setup.md#settings).
+2. Click on the “**DM Lock**” button.
+3. Enable or disable automatic closing of direct messages.
+
+![DM Lock settings screenshot](../assets/rp-settings-dm-lock.webp)
+
+## ℹ️ Command /dmlock-info {#info}
+
+The `/dmlock-info` command informs members about the current **DM Lock** status on the server. It displays a clear message indicating whether the restriction is **enabled** or **disabled**, along with an educational explanation of its purpose.
+
+**Goal:**
+- Explain why DMs are limited (to combat spam, scams, phishing).
+- Reduce confusion and repeated questions from new members.
+- Remind members of the conditions for continuing DM conversations (friends, staff, bots, existing contacts).
+
+**Example Display**
+<SeparatedBox>
+<Tabs>
+  <TabItem value="enable" label="Enabled" default>
+
+![Screenshot of the dmlock-info command enabled](../assets/rp-dm-lock-info-enable.webp)
+
+  </TabItem>
+  <TabItem value="disable" label="Disabled">
+
+![Screenshot of the dmlock-info command disabled](../assets/rp-dm-lock-info-disable.webp)
+
+  </TabItem>
+</Tabs>
+</SeparatedBox>
+
+### ⚙️ Best Practices
+
+- Encourage active members to use `/dmlock-info` to answer new members’ questions.
+- Display it regularly or pin it in your welcome channels.
+- Combine it with your rules or announcements to reinforce the server’s anti-spam policy.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/features/index.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/features/index.mdx
@@ -1,0 +1,9 @@
+---
+title: Features
+---
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/features/moderation.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/features/moderation.md
@@ -1,0 +1,41 @@
+---
+title: Moderation
+---
+
+To facilitate the work of your moderators, RaidProtect integrates very useful moderation commands that allow you to interact directly with Discord's native features, such as **banning** and **kicking** users.
+
+In addition to these actions, RaidProtect sends direct messages to the sanctioned user to explain the reason for their sanction, and this is also recorded in the server logs for your reference.
+
+:::info
+Moderation commands are [usable by prefix](../guides/prefix.md).
+:::
+
+## 🔨 Ban a User {#ban}
+
+Use the command: ```/ban [@user] [reason]```
+
+Replace `[@user]` with the desired mention or ID and `[reason]` with the reason for the sanction.
+
+:::tip
+You can ban a user using their [Discord ID](https://dfr.gg/wiki/interface/mode-developpeur), even if they are not currently online or present on your server.
+:::
+
+## 👢 Kick a User {#kick}
+
+Use the command: ```/kick [@user] [reason]```
+
+Replace `[@user]` with the desired mention or ID and `[reason]` with the reason for the sanction.
+
+## ⏳ Timeout a User {#timeout}
+
+Use the command: ```/timeout [@user] [duration] [reason]```
+
+Replace `[@user]` with the desired mention or ID, `[duration]` with the timeout length, up to a maximum of 28 days (e.g. `10m`, `1h`, `1d`), and `[reason]` with the reason for the sanction.
+
+## 🧹 Clear a Group of Messages {#clear}
+
+The command `/clear` allows you to quickly delete a certain number of messages in a text channel. You can specify a user to delete only their messages.
+
+Use the command: ```/clear [number] (@user)```
+
+Replace `[number]` with the number of messages you wish to delete (maximum 100). Add `(@user)` using the mention or ID to target only their messages in the channel.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/features/raid-mode.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/features/raid-mode.md
@@ -1,0 +1,63 @@
+---
+title: Anti-raid
+---
+
+## Raid Mode
+
+Raid mode is an emergency feature designed to instantly block all new users trying to join your server, surpassing Discord’s native limitation which only allows this block for 24 hours via the "Pause Invites" security action.
+
+### ❓ How Raid Mode Works {#working}
+
+RaidProtect automatically enables raid mode if a large number of users join your server in a short time. By default, raid mode activates if more than 10 users join your server in less than 10 seconds. When raid mode is enabled, no users can join the server. They are blocked at the invite level.
+
+:::warning
+Discord’s Community features are essential for Raid Mode to work properly. [Follow our guide to ensure Community is enabled on your server.](../guides/community.md)
+:::
+
+#### Enabling {#enable}
+
+- To manually enable this mode, a user with kick permissions must run the `/raidmode` command.
+- A message will automatically be posted in the log channel to signal activation.
+
+#### Disabling {#disable}
+
+Raid mode does not disable itself automatically. Remember to turn it off with the same command once the threat has passed. 😇
+
+:::info
+The `raidmode` command is also [available with prefix](../guides/prefix.md).
+:::
+
+### 🚨 Auto Raid Mode Configuration {#config}
+
+If your server often gets many new members at once, it’s wise to adjust this threshold to avoid false positives.
+
+![Screenshot of auto raid mode settings](../assets/rp-settings-raid-mode.webp)
+
+:::note
+We recommend setting a value between 10 and 20 members in 10 seconds for optimal system performance.
+:::
+
+1. Run the [ `/settings` command](../setup.md#settings).
+2. Click the “**Auto RaidMode**” button.
+3. Select the number of members allowed to join within 10 seconds.
+
+You can leave it at the default value (10) or adjust it to your desired value by clicking the “**Custom Value**” button.
+
+:::warning
+If raid mode is automatically triggered, don’t forget to disable it once the threat has passed. Remember, it does not turn off on its own. 😖
+:::
+
+
+## Minimum Account Age {#minage}
+
+To improve security, you can require a minimum Discord account age for new members.
+
+1. Run the [ `/settings` command](../setup.md#settings).
+2. Click the “**Minimum Age**” button.
+3. Select the desired value from the dropdown menu or choose a custom value in date format (m/h/d/y).
+
+### 🎂 Minimum Account Age Bypass {#bypass-minage}
+
+Use the command: ```/bypass minage [user]```
+
+Replace `[user]` with the desired ID; they will have 10 minutes to join the server without being kicked for not meeting the age requirement.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/features/reports.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/features/reports.md
@@ -1,0 +1,61 @@
+---
+title: Reports
+---
+
+The RaidProtect reporting system allows your community to quickly report any problematic content or suspicious users. It operates in two different ways and can be configured to optimize the reporting management process.
+
+## ❓ How Reporting Works {#working}
+Members can report content through 3 main methods.
+
+1. **Right-click on a message**  
+A member can right-click on a message they believe violates the rules, select **`Applications`**, and then click on **`Report Message`**. A popup will appear, allowing the user to add an explanation.
+
+2. **Right-click on a profile**  
+Similarly, a member can right-click on a profile they find problematic, choose **`Applications`**, and then click on **`Report Member`**. A popup will then open to allow the user to provide additional details about the situation.
+
+3. **Slash Command**  
+Members can also report a message or user via the **`/report`** command in any server channel.
+
+Use the command: ```/report [@user] [reason]```
+
+Replace `[@user]` with the desired user and `[reason]` with the reason for the infraction.
+
+## 🚩 Configuring Reports {#config}
+
+Before the reporting system is fully operational, it is imperative to configure a **report channel** where all reports will be sent. You need to set up a log or notification channel to receive alerts regarding reports.
+
+[Report settings screenshot](../assets/rp-settings-reports.webp)
+
+### Setting Up the Channel {#config-channel}
+
+1. Use the [command `/settings`](../setup.md#settings).
+2. Select the **Reports** button.
+3. Click on the **Channel** button.
+4. Choose the desired channel (_e.g. #reports_).  
+If you do not have a suitable channel, you can opt to create one automatically using the **Create one for me** button.
+
+### Configuring the Notification Role {#config-role}
+
+1. Use the [command `/settings`](../setup.md#settings).
+2. Select the **Reports** button.
+3. Click on the **Role** button.
+4. Choose the desired role (_e.g. @Moderator or @Report Ping_).  
+If you do not have a suitable role, you can opt to create one automatically with the **Create one for me** button.
+
+:::warning
+The channel should be restricted to moderators and administrators to ensure proper management of reports.
+:::
+
+## Managing Reports {#manage}
+
+As a community moderator, you can choose to accept or reject a report.
+
+- **✅ Accept a report:** If the report is valid, click the “Accept” button under the alert. This button does not trigger any specific action but indicates to other moderators that you consider this report to be handled, fostering coordination and organization.
+
+- **👁️ View Context:** To view the reported message and see the context, click “View Message” under the alert.
+
+- **❌ Reject a report:** If the report is not legitimate, click the “Reject” button under the alert. Similar to the “Accept” button, no specific action is associated with this button; it merely informs other moderators of your decision.
+
+:::note
+Ensure that your moderators are well-trained in using this feature and encourage your active members to use it responsibly!
+:::

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/features/tag-role.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/features/tag-role.md
@@ -1,0 +1,28 @@
+---
+title: Tag Role
+---
+
+The Tag Role automatically assigns a role to members who add [your server’s tag](https://support.discord.com/hc/en-us/articles/31444248479639-Server-Tags) to their Discord profile. By assigning a role to these members, you acknowledge their commitment and encourage them to actively represent your server. It’s a simple yet effective way to strengthen collective identity while rewarding your community’s most loyal ambassadors.
+
+## ❓ How the Tag Role Works {#working}
+
+It’s simple. As soon as a member adds the server’s tag to their Discord profile, RaidProtect automatically assigns them a specific role.  
+If the member removes the tag, the role is removed.
+
+:::info
+If the Tag is not enabled or your server doesn’t yet have the feature, the Tag Role will have no effect.
+:::
+
+## 🎖️ Configuring the Tag Role {#config}
+
+Configuration takes just a few clicks:  
+1. Use the [command `/settings`](../setup.md#settings).  
+2. Click the “**Tag Role**” button.  
+3. Select an existing role via the selector or click “**Create one for me**”.  
+4. You can deselect the role at any time by clicking on the “**Reset**” button.
+
+[Tag Role settings screenshot](../assets/rp-settings-tag-role.webp)
+
+:::tip
+Members will receive the role the next time they update their profile (Username, Avatar, Banner, Roles, Tag…). You can [contact support](https://raidprotect.bot/discord) to request a full role sync if you have many members who currently have or previously had the Tag.
+:::

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/features/utilities.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/features/utilities.mdx
@@ -1,0 +1,117 @@
+---
+title: Utilities
+---
+
+import SeparatedBox from '@site/src/components/SeparatedBox';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import Icon from "@site/src/components/Icon";
+
+Extra features to simplify the management of your server. 🔧
+
+In addition to core features like the captcha system and anti-raid protection, RaidProtect offers several secondary tools that can make managing your server even smoother.
+
+:::info
+Utility commands are [usable with a prefix](../guides/prefix.md).
+:::
+
+## 👤 User Information {#userinfo}
+
+The `/userinfo` command lets you get detailed information about a user.
+
+Use the command: ```/userinfo [@user]```
+
+Replace `[@user]` with the desired mention or ID.
+
+### 📋 Displayed Information {#displayed-userinfo}
+
+- **Discord account creation date**
+- User's **profile picture**
+- **Profile banner**
+- **Profile badges**
+  - The Nitro, Booster, Quest, and Originally Name badges are not displayed.
+
+
+### 🎭 Information about a server member {#displayed-memberinfo}
+
+If the target is a server member, additional info includes:
+
+- **Date joined the server**
+- **Server nickname**
+- **Number of roles** and **list of the first 6 roles**
+- **Permission category** (visible only to moderators):
+
+<SeparatedBox>
+<Tabs>
+  <TabItem value="animator" label="Animator" default>
+
+    The **Animator** category is shown if the member has **at least one** of the following permissions:
+
+    - `MANAGE_EXPRESSIONS`
+    - `CREATE_GUILD_EXPRESSIONS`
+    - `MANAGE_EVENTS`
+
+  </TabItem>
+  <TabItem value="moderator" label="Moderator">
+
+    The **Moderator** category is shown if the member has **at least one** of the following permissions:
+
+    - `KICK_MEMBERS`
+    - `BAN_MEMBERS`
+    - `MODERATE_MEMBERS`
+    - `MANAGE_MESSAGES`
+    - `MUTE_MEMBERS`
+    - `DEAFEN_MEMBERS`
+    - `MOVE_MEMBERS`
+    - `MANAGE_THREADS`
+
+  </TabItem>
+  <TabItem value="manager" label="Manager">
+
+    The **Manager** category is shown if the member has **at least one** of the following permissions:
+
+    - `MANAGE_GUILD`
+    - `MANAGE_ROLES`
+    - `MANAGE_CHANNELS`
+    - `VIEW_AUDIT_LOG`
+    - `MANAGE_WEBHOOKS`
+    - `MANAGE_SERVER_EXPRESSIONS`
+
+  </TabItem>
+  <TabItem value="admin" label="Administrator">
+
+    The **Administrator** category is shown in **two possible cases**:
+
+    1️⃣ Has the permission:
+    - `ADMINISTRATOR`
+
+    2️⃣ Has **all three** of the following permissions at the same time:
+    - `MANAGE_GUILD`
+    - `MANAGE_ROLES`
+    - `MANAGE_CHANNELS`
+
+  </TabItem>
+  <TabItem value="owner" label="Owner">
+
+    **Condition**: The member is the **server owner**.
+
+  </TabItem>
+</Tabs>
+</SeparatedBox>
+
+- **Member flags** (visible only to moderators)
+
+Certain special indicators (flags) can be displayed for a member:
+
+| **Flag**                                 | **Displayed Emoji**                                                                                                    | **Explanation**                                                   |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `DID_REJOIN`                             | <Icon src="/img/icons/MemberDidRejoin.svg" alt="icon MemberDidRejoin" title=":MemberDidRejoin:"/>                      | The user left and rejoined the server.                            |
+| `IS_GUEST`                               | <Icon src="/img/icons/MemberIsGuest.svg" alt="icon MemberIsGuest" title=":MemberIsGuest:"/>                            | Guest member (temporary invite or guest access).                  |
+| `COMPLETED_ONBOARDING`                   | <Icon src="/img/icons/OnboardingCompleted.svg" alt="icon OnboardingCompleted" title=":OnboardingCompleted:"/>          | Completed the server onboarding process.                          |
+| `STARTED_ONBOARDING`                     | <Icon src="/img/icons/OnboardingStarted.svg" alt="icon OnboardingStarted" title=":OnboardingStarted:"/>                | Started the onboarding process.                                   |
+| `COMPLETED_SERVER_GUIDE`                 | <Icon src="/img/icons/ServerGuideCompleted.svg" alt="icon ServerGuideCompleted" title=":ServerGuideCompleted:"/>       | Completed the server guide if enabled.                            |
+| `STARTED_SERVER_GUIDE`                   | <Icon src="/img/icons/ServerGuideStarted.svg" alt="icon ServerGuideStarted" title=":ServerGuideStarted:"/>             | Started the server guide.                                         |
+| `AUTOMOD_QUARANTINED_NAME`               | <Icon src="/img/icons/MemberQuarantined.svg" alt="icon MemberQuarantined" title=":MemberQuarantined:"/>                | Quarantined by automoderation for the username.                   |
+| `AUTOMOD_QUARANTINED_GUILD_TAG`          | <Icon src="/img/icons/MemberQuarantined.svg" alt="icon MemberQuarantined" title=":MemberQuarantined:"/>                | Quarantined by automoderation for the tag or nickname.            |
+| `BYPASSES_VERIFICATION`                  | <Icon src="/img/icons/BypassVerification.svg" alt="icon BypassVerification" title=":BypassVerification:"/>             | User can bypass server verification.                              |
+| `SPAMMER`                                | <Icon src="/img/icons/UnusualAccountActivity.svg" alt="icon UnusualAccountActivity" title=":UnusualAccountActivity:"/> | Account marked as spammer or unusual activity detected.           |

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/guides/community.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/guides/community.md
@@ -1,0 +1,37 @@
+---
+title: Enable Community
+---
+
+Enabling the Community feature unlocks several advanced security settings essential for the proper functioning of some RaidProtect features like **DM Lock** or **Raid Mode**.
+
+## 🚦 Requirements {#requirement}
+
+- You must be an administrator of the Discord server.
+
+## 🚩 Enable Community Features {#steps}
+
+1. **Open your server settings**
+   - Click on the server name at the top left > “Server Settings”.
+
+2. **Go to the “Community” section**
+   - In the sidebar, navigate to the **Enable Community** tab and click **Get Started**.
+
+:::note
+If Community is already enabled on your server, the section will be called **Community Overview**.
+:::
+
+3. **Follow the setup wizard**
+   - Enable email verification for all members.
+   - Enable the explicit content filter.
+   - Set up a rules channel and an updates channel.
+   - Accept the Community Server guidelines.
+
+4. **Complete the setup**
+   - Click “Finish Setup”. The “Community” badge will appear on your server once activation is complete.
+
+![Discord Community activation screenshot](../assets/rp-enable-community.webp)
+
+## 💡 Use DM Lock & Raid Mode modules after activation {#use}
+
+- Run the [`/settings`](../setup.md#settings) command to open the RaidProtect configuration menu.
+- Enable or disable the desired modules (DM Lock, Raid Mode, etc.) from the interactive menu.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/guides/id.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/guides/id.mdx
@@ -1,0 +1,98 @@
+---
+title: Using IDs
+---
+
+import SeparatedBox from '@site/src/components/SeparatedBox';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Discord IDs are unique numbers that precisely identify each user, channel, server, or message on Discord. They are a reliable and permanent way to identify elements on the platform.
+
+:::note Relevance for Moderation
+Using Discord IDs is especially useful for moderation actions because it allows you to:
+- **Sanction an absent user**: Ban someone who has left the server
+- **Avoid mistakes**: Precisely identify the right person even with similar usernames
+- **Keep track**: IDs never change, unlike usernames
+- **Conflict resolution**: Clear identification in case of special characters
+:::
+
+## Enabling Developer Mode
+
+You need to enable Developer Mode to use Discord IDs.
+
+<SeparatedBox>
+<Tabs>
+  <TabItem value="desktop" label="On Discord Desktop/Web" default>
+
+    1. **Open User Settings**
+    - Click the gear icon ⚙️ at the bottom left of the interface
+
+    2. **Access Advanced Settings**
+    - In the sidebar, go to the **Advanced** tab
+
+    3. **Enable Developer Mode**
+    - Turn on the **"Developer Mode"** option by clicking the toggle button
+    - The button should turn blue once enabled
+
+  </TabItem>
+  <TabItem value="mobile" label="On Discord Mobile">
+
+    1. **Open User Settings**
+    - Tap your avatar at the bottom right
+    - Tap the gear icon ⚙️ at the top right of the interface
+
+    2. **Access Advanced Settings**
+    - Scroll down and tap **"Advanced"**
+
+    3. **Enable Developer Mode**
+    - Turn on the **"Developer Mode"** option
+
+  </TabItem>
+</Tabs>
+</SeparatedBox>
+
+## Copying an ID
+
+Once Developer Mode is enabled, you can copy the ID of any element:
+
+<SeparatedBox>
+<Tabs>
+  <TabItem value="user" label="User ID" default>
+
+    - **Right-click** on the avatar or username
+    - Select **"Copy User ID"**
+
+  </TabItem>
+  <TabItem value="channel" label="Channel ID">
+
+    - **Right-click** on the channel name in the channel list
+    - Select **"Copy Channel ID"**
+
+  </TabItem>
+  <TabItem value="server" label="Server ID">
+
+    - **Right-click** on the server name at the top left
+    - Select **"Copy Server ID"**
+
+  </TabItem>
+  <TabItem value="message" label="Message ID">
+
+    - **Right-click** on a message
+    - Select **"Copy Message ID"**
+
+  </TabItem>
+</Tabs>
+</SeparatedBox>
+
+## Using with RaidProtect
+
+IDs can be used in RaidProtect commands instead of mentions:
+
+- [`/ban user:123456789012345678 reason:Server rules violation`](../features/moderation#ban)
+- [`/clear amount:100 user:123456789012345678`](../features/moderation#clear)
+- [`/userinfo user:123456789012345678`](../features/utilities#userinfo)
+- [`/bypass mining user:123456789012345678`](../features/raid-mode#minage)
+
+:::info
+You can ban a user using their Discord ID, even if they are not online or present in your server.
+:::

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/guides/index.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/guides/index.mdx
@@ -1,0 +1,9 @@
+---
+title: Guides
+---
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/guides/malfunctions.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/guides/malfunctions.md
@@ -1,0 +1,61 @@
+---
+title: Malfunctions
+---
+
+Having an issue with RaidProtect? The solution is likely here.
+
+Sometimes things don't work as expected. Here are the **most common problems** you may encounter, along with how to solve them. 🤗 
+
+If this page does not answer a problem you're experiencing, [**feel free to contact our support**](https://raidprotect.bot/discord) who will be happy to help you!
+
+## The bot shows an error when I run a command {#commands}
+
+If the command does not execute successfully, **RaidProtect may display an error** instead of the expected result. In most cases, there will be an indication in the message, but it may be a more generic message. Here’s how to resolve this issue in most cases. 🧐 
+
+- **Do what is indicated.** Some errors clearly explain the problem. If the bot asks you to do something, please do it.
+
+- **Check the command parameters.** The command might simply be misspelled; check the help on how to use it. Remember that brackets ([]) are not to be included.
+
+- **Check the bot's permissions.** The bot must have **Administrator** permission and be at the administrator level in the role hierarchy.
+
+- **Retry the command.** Sometimes the issue resolves itself for unknown reasons.
+
+If you continue to receive an error despite following these tips, [contact our support](https://raidprotect.bot/discord) so we can assist you. 🤝 
+
+## The bot's log channel didn't create itself {#logs}
+
+To notify you of the actions it takes, RaidProtect needs a log channel. This channel is created automatically when the bot first joins, but sometimes no channel is created. Here’s how to remedy this issue. ⚙️ 
+
+- **Ensure the bot is an Administrator.** For the bot to function properly, it must be given Administrator permission. If this is not done, go to the role settings and grant this permission to the RaidProtect role. You then just need to manually initialize the bot for everything to work (see below)!
+
+- **Check that the bot is properly initialized.** This is usually done automatically, but you can force this initialization with the [command `/setup`](../setup.md#install). The log channel should be created automatically.
+
+- **Manually set a channel.** If nothing works, don’t panic; you can manually choose the channel the bot will use for logs! Once a dedicated channel is created, execute the [command /settings](../setup.md#settings) and then select Logs.
+
+## A user spammed, but the bot did not sanction them {#anti-spam}
+
+The [anti-spam](../features/anti-spam.mdx) feature is one of RaidProtect's main functionalities, and it can be frustrating if it’s not working. But rest assured, most of the time it’s nothing serious. 😇 
+
+- **If the anti-spam asks to stop the spam but does not sanction,** this is likely due to a lack of permissions. Remember, the bot must have Administrator permission and must be at the administrator level in the role hierarchy.
+
+- **Check the anti-spam configuration.** It’s quite simple, but some forget that they have ignored a channel.
+
+- **Check the spammer's permissions.** Administrators are ignored, so if you’re testing the anti-spam on your own server, it may not detect you.
+
+- **Is the spam long enough?** The bot generally only detects spam if it’s more than 5 messages. Don’t be too hasty.
+
+If spam is still not detected, [contact us on our support server](https://raidprotect.bot/discord) with a **screenshot of the issue**.
+
+## Users have access to the server without completing the captcha {#captcha}
+
+This problem is relatively common, but it depends on **your server configuration**. Let’s see how to fix it. 🏥 
+
+- **Do you have an auto role?** If you have set up a bot (other than RaidProtect) to give a role to newcomers on your server, this may interfere with the captcha. Replace it with the [RaidProtect autorole](../features/captcha.md#autorole). 
+
+- **Have you activated the captcha?** This is a completely optional feature that requires you to execute a command to enable it. Check the [dedicated captcha documentation page](../features/captcha.md#config) for more information.
+
+## Users can still talk when I lock a channel {#lock}
+
+The lock command seems magical, but it has its weaknesses. As [noted in this documentation](../features/channel-lock.md#lock), the command **only affects the @everyone role**. This means that if there is a role in the channel you want to lock that explicitly has permission to speak, they will still be able to do so. A picture is worth a thousand words, so here’s what that looks like in practice. 🔍 
+
+[Screenshot of channel lock configuration](../assets/lock-channel-messages-raidprotect.png)

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/guides/onboarding.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/guides/onboarding.md
@@ -1,0 +1,52 @@
+---
+title: Onboarding Process and Captcha
+---
+
+If the `#verification` channel is not visible by default for new members, this can prevent the Captcha system from working properly. Here’s how to fix this issue step by step.
+
+![Captcha alert screenshot](../assets/rp-settings-captcha-alert.webp)
+
+## 1️⃣ Check the channel permissions {#permissions}
+
+1. Open the `#verification` channel settings (right-click > **Edit Channel**).
+2. In the **Permissions** tab:
+   - Make sure `@everyone` **does not** have permission to view the channel.
+   - Ensure the `@Unverified` role **has** permission to **view the channel**, **read message history**, and **send messages**.
+
+![Screenshot channel permissions check](../assets/rp-verification-channel-permissions.webp)
+
+## 2️⃣ Check the Welcome category {#default-category}
+
+1. Go to **Server Settings** > **Onboarding**.
+2. In the **Default Channels** section, verify that the category containing `#verification` is checked as visible for new members.
+3. If needed, move `#verification` into a checked category.
+4. Save the changes.
+
+![Screenshot welcome category check](../assets/rp-welcome-category.webp)
+
+## 3️⃣ Refresh the configuration in RaidProtect {#refresh-config}
+
+1. Use the [`/settings`](../setup.md#settings) command and go to the **Captcha** tab.
+2. Click **Refresh** to force the configuration update.
+3. If the channel is now visible, the Captcha system will work correctly.
+
+## 4️⃣ Test with a test account {#test-account}
+
+To confirm everything is set up properly:
+
+1. Join the server with another Discord account.
+2. Check that the `#verification` channel is visible on arrival.
+3. Enter the Captcha code sent by RaidProtect.
+4. Once verified, the account should have access to the other channels.
+
+## 🛠️ Common issues and solutions {#common-issues}
+
+| Issue | Solution |
+|-------|----------|
+| 🔴 The `#verification` channel remains invisible | Check that it is in a **checked category** in Discord’s Welcome settings. |
+| 🚫 The `@Unverified` role cannot write | Grant it **send messages** permission in `#verification`. |
+| ❌ Captcha doesn’t work after changes | Click **“Refresh”** in `/settings > Captcha`. |
+
+---
+
+✅ By following these steps, your verification system will be fully operational to safely welcome members and effectively block bots or raids.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/guides/prefix.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/guides/prefix.md
@@ -1,0 +1,32 @@
+---
+title: Using a prefix
+---
+
+## Disabled Prefix (Default) {#disabled}
+
+By default, RaidProtect uses only Slash commands (`/`) to interact with the bot. This ensures intuitive and consistent usage with Discord standards.
+
+## Activated Prefix (Optional) {#activated}
+
+If you prefer to use certain commands with a custom prefix, you can enable this option. The default prefix when activated is `?`, but it can be modified to suit your needs. Once activated, these commands can be used with the configured prefix: 
+- [`?raidmode`](../features/raid-mode.md)
+- [`?ban`](../features/moderation.md#ban)
+- [`?kick`](../features/moderation.md#kick)
+- [`?lock`](../features/channel-lock.md#lock)
+- [`?unlock`](../features/channel-lock.md#unlock)
+- [`?userinfo` | `?ui`](../features/utilities#userinfo)
+- [`?clear`](../features/moderation#clear)
+
+## 💬 How to Enable or Disable the Prefix {#config}
+
+1. Open the configuration menu by typing [`/settings`](../setup.md#settings).
+2. Access the "**Prefix**" option for commands.
+3. Enable or disable the prefix according to your preferences.
+If enabled, customize the prefix by entering the desired character or string.
+
+![Prefix settings screenshot](../assets/rp-settings-prefix.webp)
+
+:::note
+Slash commands (`/`) remain available even if the prefix is activated.
+It is recommended to avoid prefixes already used by other bots to prevent command conflicts.
+:::

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/guides/report-violation-to-discord.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/guides/report-violation-to-discord.md
@@ -1,0 +1,35 @@
+---
+title: Report a violation to Discord
+---
+
+Have you encountered a malicious user on Discord? Report them so that they can be sanctioned.
+
+On Discord, some users may not have good intentions. If they display behavior that is particularly harmful to the community, it is advisable to **report it to Discord's Trust & Safety team**. If the violation is found to be valid, the user may face sanctions ranging from a warning to account deletion. 😖 
+
+## 🧐 What Types of Violations to Report? {#types-of-violations}
+
+Of course, not all types of violations are subject to account deletion. Punishable behaviors are described in **Discord's [Community Guidelines](https://discord.com/guidelines)** (as well as in the [Terms of Service](https://discord.com/terms), which is more legal jargon than clear instructions). The list of report types on the reporting page is a great summary for those hesitant to read extensively.
+
+In general, **harmful behaviors to the community** (spam, promotion of illegal content, etc.) or **serious harm to a user** (doxxing, harassment) should be reported.
+
+For less extreme behaviors, **prefer banning** (on a server) or [blocking](https://support.discordapp.com/hc/en-us/articles/217916488-Blocking-and-Privacy-Settings) (throughout Discord). If you are not a moderator on the server where the actions are happening, feel free to report it to the moderation team, who must take action.
+
+## 🕵️ Collecting Evidence {#recover-evidences}
+
+To make a report, you need to provide evidence. First, note that **screenshots are not useful**; they can be easily falsified. You will need at least one (or preferably several) message links.
+
+**These links are very easy to obtain**. On a message corresponding to the violation you wish to report, right-click > Copy Message Link (on desktop) or Long press > Share > Copy to Clipboard (on mobile).
+
+## 📪 Reporting the Violation to the _Trust & Safety_ Team {#report-to-tns}
+
+Filing a report is very easy and takes only a few minutes. First, go to the **dedicated form** by following the link **https://dis.gd/report**.
+
+[Screenshot of Discord report](../assets/discord-report.png)
+
+Depending on the type of report selected, **different information will be requested**. Enter the link to the message obtained in the previous step in the appropriate field (and possibly the others in the description). Don’t hesitate to be **as thorough as possible** and remember the basic rules of politeness. 😇 
+
+### 📨 Discord's Response {#discord-response}
+
+A few days after your report—generally within a week—you should receive **a response via email** from Discord. Note that you will not be able to know the sanctions taken (or not) against the reported user. 😒
+
+[Screenshot of Discord response](../assets/discord-reply.png)

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/language.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/language.md
@@ -1,0 +1,32 @@
+---
+title: Language
+---
+
+RaidProtect allows you to choose the language used by the bot to best suit your Discord community.
+
+:::note
+If your server is set as a community server (Discord setting), RaidProtect will by default use the language configured in the server's **community settings**.
+:::
+
+**Public Messages:** The configured language only affects public messages sent by RaidProtect in your server (logs, captcha messages, reports, etc.).
+
+**Ephemeral Messages:** These private or temporary messages remain displayed in the language of the user interacting with the bot.
+
+## 🌐 List of Supported Languages {#supported}
+
+- **French**
+- **English**
+
+## ⚙️ Changing the Bot's Language {#change}
+
+- Use the [`/settings` command](./setup.md#settings).
+- Select the “**Language**” button.
+- Choose the desired language.
+
+![Screenshot of language settings](./assets/rp-settings-language.webp)
+
+Once the language is selected, the bot will automatically adapt all its messages, notifications, and commands to the chosen language for your server.
+
+:::info
+RaidProtect's language support is constantly evolving! [Suggest](https://suggestions.raidprotect.bot) languages you'd like to see on the bot or [vote](https://suggestions.raidprotect.bot) for proposed languages to have them added.
+:::

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/readme.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/readme.mdx
@@ -1,0 +1,50 @@
+---
+title: Read Me
+slug: /
+---
+
+import DocCard from '@theme/DocCard';
+
+This documentation aims to explain how RaidProtect works. Feel free to send us your feedback so we can improve it.
+Don't forget to [join our Discord server](https://raidprotect.bot/discord) to stay informed about the latest updates on the project. You can also contact our support team who will answer your questions about using the bot. 😄
+
+## 🚀 Getting Started with RaidProtect {#start}
+
+To start using RaidProtect, simply invite it to your server using the following link.
+
+<DocCard item={{ type: 'link', href: 'https://raidprotect.bot/invite', label: 'Invite RaidProtect' }} />
+<br />
+
+:::danger
+Warning, **copies of the bot** are circulating **using the name RaidProtect**, only invite it from our official website.
+:::
+
+### Requirements {#requirement}
+
+To ensure the proper functioning of RaidProtect:
+1. **Grant the Administrator permission** to RaidProtect. This allows it to automatically moderate all your channels.
+2. **Place its role at the same level as your server administrators**. The permission system does not allow RaidProtect to sanction users with a role above it.
+
+### Installation {#install}
+
+Once RaidProtect is added to your server, run the [`/setup`](./setup.md#install) command.
+
+<DocCard item={{ type: 'link', href: '/setup', docId: 'setup', label: 'Guided Installation' }} />
+<br />
+
+:::note
+For the less adventurous (or the more impatient), you can simply read the instructions of the [`/setup`](./setup.md#advanced) command which summarizes the main information of each feature.
+:::
+
+### Usage {#use}
+
+Check out the different sections of this documentation to discover all the features offered by RaidProtect.
+
+<DocCard item={{ type: 'link', href: '/language', docId: 'language', label: 'Available Languages' }} />
+<br />
+<DocCard item={{ type: 'category', href: '/features', label: 'Features', description: 'Documentation for each of our features.' }} />
+<br />
+<DocCard item={{ type: 'category', href: '/guides', label: 'Our Guides', description: 'Guides to help you the best way possible.' }} />
+<br />
+<DocCard item={{ type: 'category', href: '/useful-links', label: 'Useful Links', description: 'Various useful links for RaidProtect.' }} />
+<br />

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/setup.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/setup.md
@@ -1,0 +1,58 @@
+---
+title: Installation
+---
+
+RaidProtect simplifies server management with two powerful tools: the [`/setup`](#install) command for a step-by-step guided setup and the [`/settings`](#settings) command to adjust your settings at any time through a centralized menu. This installation guide explains how to use them effectively.
+
+## Guided Installation {#install}
+
+The `/setup` command is designed to help you configure RaidProtect quickly or through a detailed approach, depending on your needs. It offers two configuration modes: [recommended](#recommended) or [advanced](#advanced).
+
+### 🔧 Recommended Configuration {#recommended}
+
+Allows you to enable or disable core features at a glance using an interactive selection menu.
+
+1. Use the `/setup` command.
+2. Select the “**Recommended Configuration**” button.
+3. Enable or disable the desired features using the selection menu.
+
+The bot will then send you a summary of the activated features and the changes it will make to the server.
+
+![Recommended configuration screenshot](./assets/rp-setup.webp)
+
+<!--
+### 🛠️ Advanced Configuration {#advanced}
+
+If you want to configure the bot more thoroughly, opt for the advanced configuration. The bot guides you step by step with clear explanations.
+
+1. Use the `/setup` command.
+2. Select the “**Advanced Configuration**” button.
+3. Each step introduces a feature, its purpose, and a recommended minimum configuration.
+4. Use the “**Previous**” and “**Next**” buttons to move forward or go back.
+
+At the end, a summary of the settings is displayed to confirm your choices.
+-->
+## Modifying the Configuration {#settings}
+
+The `/settings` command is the go-to command for managing your settings after installation. It allows you to view, adjust, or customize RaidProtect's features at any time, in a simple and fast way.
+
+### 🔍 Settings Menu {#menu}
+
+1. Type `/settings` in a channel where the bot is active.
+2. Easily navigate between different sections to find the settings you want to modify.
+3. Adjust the options: Each category presents a list of customizable options in the form of buttons or dropdown menus.
+
+![Settings screenshot](./assets/rp-settings.webp)
+
+### 🔄 Resetting a Setting {#reset}
+
+1. Navigate to the desired setting.
+2. Click on “**Reset**”.
+
+![Reset button screenshot](./assets/rp-button-reset.webp)
+
+The bot will confirm the reset before applying the changes.
+
+:::info Configuration Issue?
+If you encounter a problem, check the [Malfunctions](./guides/malfunctions) section or join our [support server](https://raidprotect.bot/discord) for assistance.
+:::

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/useful-links/index.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/useful-links/index.mdx
@@ -1,0 +1,9 @@
+---
+title: Useful links
+---
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```

--- a/i18n/de/docusaurus-theme-classic/footer.json
+++ b/i18n/de/docusaurus-theme-classic/footer.json
@@ -1,0 +1,50 @@
+{
+  "copyright": {
+    "message": "© 2025 SAS French Community Agency, RaidProtect. Alle Rechte vorbehalten.",
+    "description": "The footer copyright"
+  },
+  "logo.alt": {
+    "message": "RaidProtect",
+    "description": "The alt text of footer logo"
+  },
+  "link.title.Navigation": {
+    "message": "Navigation",
+    "description": "The title of the footer links column with title=Navigation in the footer"
+  },
+  "link.title.Information": {
+    "message": "Informationen",
+    "description": "The title of the footer links column with title=Information in the footer"
+  },
+  "link.item.label.Accueil": {
+    "message": "Startseite",
+    "description": "The label of footer link with label=Accueil linking to main"
+  },
+  "link.item.label.Documentation": {
+    "message": "Dokumentation",
+    "description": "The label of footer link with label=Documentation linking to /"
+  },
+  "link.item.label.Suggestions": {
+    "message": "Vorschläge",
+    "description": "The label of footer link with label=Suggestions linking to https://suggestions.raidprotect.bot"
+  },
+  "link.item.label.Mentions légales": {
+    "message": "Impressum",
+    "description": "The label of footer link with label=Mentions légales linking to legal"
+  },
+  "link.item.label.Statuts des services": {
+    "message": "Status der Dienste",
+    "description": "The label of footer link with label=Statuts des services linking to https://status.raidprotect.bot"
+  },
+  "link.item.label.Blog": {
+    "message": "Blog",
+    "description": "The label of footer link with label=Blog linking to /blog"
+  },
+  "link.item.label.Conditions d'utilisation": {
+    "message": "Nutzungsbedingungen",
+    "description": "The label of footer link with label=Conditions d'utilisation linking to terms"
+  },
+  "link.item.label.Politique de confidentialité": {
+    "message": "Datenschutzerklärung",
+    "description": "The label of footer link with label=Politique de confidentialité linking to privacy"
+  }
+}

--- a/i18n/de/docusaurus-theme-classic/navbar.json
+++ b/i18n/de/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,22 @@
+{
+  "logo.alt": {
+    "message": "RaidProtect",
+    "description": "The alt text of navbar logo"
+  },
+  "item.label.Accueil": {
+    "message": "Startseite",
+    "description": "Navbar item with label Accueil"
+  },
+  "item.label.Documentation": {
+    "message": "Dokumentation",
+    "description": "Navbar item with label Documentation"
+  },
+  "item.label.Suggestions": {
+    "message": "Vorschläge",
+    "description": "Navbar item with label Suggestions"
+  },
+  "item.label.Blog": {
+    "message": "Blog",
+    "description": "Navbar item with label Blog"
+  }
+}


### PR DESCRIPTION
## Summary
- start adding German locale based on English files
- translate README, sample blog post, navbar/footer, and some strings
- include placeholders for remaining content

## Testing
- `npm run typecheck` *(fails: modules not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a832ffe3483209c0706914996850b