### PR TITLE
Fix broken German image links

### DIFF
--- a/i18n/de/docusaurus-plugin-content-blog/3.1.0/3.1.0-interactions-update.md
+++ b/i18n/de/docusaurus-plugin-content-blog/3.1.0/3.1.0-interactions-update.md
@@ -2,14 +2,14 @@
 title: 'Interactions Update (3.1.0)'
 tags: [release, language]
 authors: [derrios, zallom]
-image: ./assets/rp-interactions-update.webp
+image: ../../../en/docusaurus-plugin-content-blog/3.1.0/assets/rp-interactions-update.webp
 slug: 3.1.0-interactions-update
 date: 2025-03-12
 ---
 
 It’s been a while since we last released a major update for RaidProtect, and we sincerely apologize for the long wait. Over the past few months, we’ve been working hard to modernize and improve the bot experience. Today, we’re excited to introduce the **Interactions Update**!
 
-![RaidProtect Interactions Update blog post social card](./assets/rp-interactions-update.webp)
+![RaidProtect Interactions Update blog post social card](../../../en/docusaurus-plugin-content-blog/3.1.0/assets/rp-interactions-update.webp)
 
 <!--truncate-->
 
@@ -33,7 +33,7 @@ We’ve laid the groundwork for a [**multilingual system**](/language) and added
 
 A long-requested feature: [**a reporting system**](/features/reports) that allows your community to easily report incidents on your server.
 
-![Screenshot of the report menu](./assets/rp-report-message.webp)
+![Screenshot of the report menu](../../../en/docusaurus-plugin-content-blog/3.1.0/assets/rp-report-message.webp)
 
 ### New Configuration Commands {#configuration}
 
@@ -42,7 +42,7 @@ We know that setting up a bot can quickly become a headache, so we’ve made it 
 - **A brand-new [`/setup`](/setup#install)** to guide you right from the installation process.
 - **More flexible options** for fine-tuned configuration.
 
-![Screenshot of the configuration menu](./assets/rp-configuration-menu.webp)
+![Screenshot of the configuration menu](../../../en/docusaurus-plugin-content-blog/3.1.0/assets/rp-configuration-menu.webp)
 
 ### A Better User Experience {#ux}
 

--- a/i18n/de/docusaurus-plugin-content-blog/3.1.1/3.1.1-tag-role.md
+++ b/i18n/de/docusaurus-plugin-content-blog/3.1.1/3.1.1-tag-role.md
@@ -2,14 +2,14 @@
 title: 'An Automatic Role Linked to the Server Tag (3.1.1)'
 tags: [release]
 authors: [derrios]
-image: ./assets/rp-tag-role.webp
+image: ../../../en/docusaurus-plugin-content-blog/3.1.1/assets/rp-tag-role.webp
 slug: 3.1.1-tag-role
 date: 2025-05-21
 ---
 
 Looking to automatically assign a **Discord tag role** to your members? Want to give a role when someone wears your **Discord server tag**? Good news: RaidProtect 3.1.1 introduces the **Tag Role** feature.
 
-![RaidProtect Tag Role blog post social card](./assets/rp-tag-role.webp)
+![RaidProtect Tag Role blog post social card](../../../en/docusaurus-plugin-content-blog/3.1.1/assets/rp-tag-role.webp)
 
 <!--truncate-->
 

--- a/i18n/de/docusaurus-plugin-content-blog/3.2.0/3.2.0-protection-update.md
+++ b/i18n/de/docusaurus-plugin-content-blog/3.2.0/3.2.0-protection-update.md
@@ -2,14 +2,14 @@
 title: 'Protection Update (3.2.0)'
 tags: [release]
 authors: [derrios]
-image: ./assets/rp-protection-update.webp
+image: ../../../en/docusaurus-plugin-content-blog/3.2.0/assets/rp-protection-update.webp
 slug: 3.2.0-protection-update
 date: 2025-07-10
 ---
 
 Version 3.2.0 marks a major milestone for the security of your Discord community with the introduction of DM Lock – an all-new shield against spam, scams, and private message fraud.
 
-![RaidProtect Protection Update blog post social card](./assets/rp-protection-update.webp)
+![RaidProtect Protection Update blog post social card](../../../en/docusaurus-plugin-content-blog/3.2.0/assets/rp-protection-update.webp)
 
 <!--truncate-->
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/features/anti-spam.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/features/anti-spam.mdx
@@ -25,7 +25,7 @@ RaidProtect offers three security levels to meet your server's needs.
 - 🟠 **Medium:** Sanctions all spam but respects ignored channels.
 - 🟢 **Low:** Sanctions only heavy spam.
 
-![Anti-spam settings screenshot](../assets/rp-settings-anti-spam.webp)
+![Anti-spam settings screenshot](../../../../en/docusaurus-plugin-content-docs/current/assets/rp-settings-anti-spam.webp)
 
 ### Changing the Security Level {#level}
 
@@ -76,7 +76,7 @@ Here are the different **available sanctions** as well as the **triggers** that 
 | Link spam                              | Mass sending of links                                   | 24 hours           |
 | Duplicate or heavy spam                | Copied messages or excessive spam                       | 24 hours           |
 
-![Screenshot of anti-spam sanctions](../assets/rp-settings-anti-spam-sanctions.webp)
+![Screenshot of anti-spam sanctions](../../../../en/docusaurus-plugin-content-docs/current/assets/rp-settings-anti-spam-sanctions.webp)
 
 ## 📑 Anti-spam Logs {#logs}
 
@@ -86,12 +86,12 @@ Detailed logs are generated with all messages deleted by the anti-spam. You can 
 <Tabs>
   <TabItem value="animator" label="Collapsed" default>
 
-![Screenshot of anti-spam logs](../assets/rp-logs-anti-spam.webp)
+![Screenshot of anti-spam logs](../../../../en/docusaurus-plugin-content-docs/current/assets/rp-logs-anti-spam.webp)
 
   </TabItem>
   <TabItem value="moderator" label="Expanded">
 
-![Screenshot of expanded anti-spam logs](../assets/rp-logs-anti-spam-expand.webp)
+![Screenshot of expanded anti-spam logs](../../../../en/docusaurus-plugin-content-docs/current/assets/rp-logs-anti-spam-expand.webp)
 
   </TabItem>
 </Tabs>

--- a/i18n/de/docusaurus-plugin-content-docs/current/features/captcha.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/features/captcha.md
@@ -32,7 +32,7 @@ Setting up captcha is quick and easy.
 4. The **@Unverified** role is automatically created and configured.
 5. Configure the allowed number of attempts (between **1 and 3**) and the maximum resolution time (between **1 and 10 minutes**).
 
-![Captcha settings screenshot](../assets/rp-settings-captcha.webp)
+![Captcha settings screenshot](../../../../en/docusaurus-plugin-content-docs/current/assets/rp-settings-captcha.webp)
 
 ## ✨ Additional Features {#additional-features}
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/features/dm-lock.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/features/dm-lock.mdx
@@ -35,7 +35,7 @@ Discord’s community features are essential for DM Lock to function properly. [
 2. Click on the “**DM Lock**” button.
 3. Enable or disable automatic closing of direct messages.
 
-![DM Lock settings screenshot](../assets/rp-settings-dm-lock.webp)
+![DM Lock settings screenshot](../../../../en/docusaurus-plugin-content-docs/current/assets/rp-settings-dm-lock.webp)
 
 ## ℹ️ Command /dmlock-info {#info}
 
@@ -51,12 +51,12 @@ The `/dmlock-info` command informs members about the current **DM Lock** status 
 <Tabs>
   <TabItem value="enable" label="Enabled" default>
 
-![Screenshot of the dmlock-info command enabled](../assets/rp-dm-lock-info-enable.webp)
+![Screenshot of the dmlock-info command enabled](../../../../en/docusaurus-plugin-content-docs/current/assets/rp-dm-lock-info-enable.webp)
 
   </TabItem>
   <TabItem value="disable" label="Disabled">
 
-![Screenshot of the dmlock-info command disabled](../assets/rp-dm-lock-info-disable.webp)
+![Screenshot of the dmlock-info command disabled](../../../../en/docusaurus-plugin-content-docs/current/assets/rp-dm-lock-info-disable.webp)
 
   </TabItem>
 </Tabs>

--- a/i18n/de/docusaurus-plugin-content-docs/current/features/raid-mode.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/features/raid-mode.md
@@ -31,7 +31,7 @@ The `raidmode` command is also [available with prefix](../guides/prefix.md).
 
 If your server often gets many new members at once, it’s wise to adjust this threshold to avoid false positives.
 
-![Screenshot of auto raid mode settings](../assets/rp-settings-raid-mode.webp)
+![Screenshot of auto raid mode settings](../../../../en/docusaurus-plugin-content-docs/current/assets/rp-settings-raid-mode.webp)
 
 :::note
 We recommend setting a value between 10 and 20 members in 10 seconds for optimal system performance.

--- a/i18n/de/docusaurus-plugin-content-docs/current/features/reports.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/features/reports.md
@@ -24,7 +24,7 @@ Replace `[@user]` with the desired user and `[reason]` with the reason for the i
 
 Before the reporting system is fully operational, it is imperative to configure a **report channel** where all reports will be sent. You need to set up a log or notification channel to receive alerts regarding reports.
 
-[Report settings screenshot](../assets/rp-settings-reports.webp)
+[Report settings screenshot](../../../../en/docusaurus-plugin-content-docs/current/assets/rp-settings-reports.webp)
 
 ### Setting Up the Channel {#config-channel}
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/features/tag-role.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/features/tag-role.md
@@ -21,7 +21,7 @@ Configuration takes just a few clicks:
 3. Select an existing role via the selector or click “**Create one for me**”.  
 4. You can deselect the role at any time by clicking on the “**Reset**” button.
 
-[Tag Role settings screenshot](../assets/rp-settings-tag-role.webp)
+[Tag Role settings screenshot](../../../../en/docusaurus-plugin-content-docs/current/assets/rp-settings-tag-role.webp)
 
 :::tip
 Members will receive the role the next time they update their profile (Username, Avatar, Banner, Roles, Tag…). You can [contact support](https://raidprotect.bot/discord) to request a full role sync if you have many members who currently have or previously had the Tag.

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/community.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/community.md
@@ -29,7 +29,7 @@ If Community is already enabled on your server, the section will be called **Com
 4. **Complete the setup**
    - Click “Finish Setup”. The “Community” badge will appear on your server once activation is complete.
 
-![Discord Community activation screenshot](../assets/rp-enable-community.webp)
+![Discord Community activation screenshot](../../../../en/docusaurus-plugin-content-docs/current/assets/rp-enable-community.webp)
 
 ## 💡 Use DM Lock & Raid Mode modules after activation {#use}
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/malfunctions.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/malfunctions.md
@@ -58,4 +58,4 @@ This problem is relatively common, but it depends on **your server configuration
 
 The lock command seems magical, but it has its weaknesses. As [noted in this documentation](../features/channel-lock.md#lock), the command **only affects the @everyone role**. This means that if there is a role in the channel you want to lock that explicitly has permission to speak, they will still be able to do so. A picture is worth a thousand words, so here’s what that looks like in practice. 🔍 
 
-[Screenshot of channel lock configuration](../assets/lock-channel-messages-raidprotect.png)
+[Screenshot of channel lock configuration](../../../../en/docusaurus-plugin-content-docs/current/assets/lock-channel-messages-raidprotect.png)

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/onboarding.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/onboarding.md
@@ -4,7 +4,7 @@ title: Onboarding Process and Captcha
 
 If the `#verification` channel is not visible by default for new members, this can prevent the Captcha system from working properly. Here’s how to fix this issue step by step.
 
-![Captcha alert screenshot](../assets/rp-settings-captcha-alert.webp)
+![Captcha alert screenshot](../../../../en/docusaurus-plugin-content-docs/current/assets/rp-settings-captcha-alert.webp)
 
 ## 1️⃣ Check the channel permissions {#permissions}
 
@@ -13,7 +13,7 @@ If the `#verification` channel is not visible by default for new members, this c
    - Make sure `@everyone` **does not** have permission to view the channel.
    - Ensure the `@Unverified` role **has** permission to **view the channel**, **read message history**, and **send messages**.
 
-![Screenshot channel permissions check](../assets/rp-verification-channel-permissions.webp)
+![Screenshot channel permissions check](../../../../en/docusaurus-plugin-content-docs/current/assets/rp-verification-channel-permissions.webp)
 
 ## 2️⃣ Check the Welcome category {#default-category}
 
@@ -22,7 +22,7 @@ If the `#verification` channel is not visible by default for new members, this c
 3. If needed, move `#verification` into a checked category.
 4. Save the changes.
 
-![Screenshot welcome category check](../assets/rp-welcome-category.webp)
+![Screenshot welcome category check](../../../../en/docusaurus-plugin-content-docs/current/assets/rp-welcome-category.webp)
 
 ## 3️⃣ Refresh the configuration in RaidProtect {#refresh-config}
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/prefix.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/prefix.md
@@ -24,7 +24,7 @@ If you prefer to use certain commands with a custom prefix, you can enable this 
 3. Enable or disable the prefix according to your preferences.
 If enabled, customize the prefix by entering the desired character or string.
 
-![Prefix settings screenshot](../assets/rp-settings-prefix.webp)
+![Prefix settings screenshot](../../../../en/docusaurus-plugin-content-docs/current/assets/rp-settings-prefix.webp)
 
 :::note
 Slash commands (`/`) remain available even if the prefix is activated.

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/report-violation-to-discord.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/report-violation-to-discord.md
@@ -24,7 +24,7 @@ To make a report, you need to provide evidence. First, note that **screenshots a
 
 Filing a report is very easy and takes only a few minutes. First, go to the **dedicated form** by following the link **https://dis.gd/report**.
 
-[Screenshot of Discord report](../assets/discord-report.png)
+[Screenshot of Discord report](../../../../en/docusaurus-plugin-content-docs/current/assets/discord-report.png)
 
 Depending on the type of report selected, **different information will be requested**. Enter the link to the message obtained in the previous step in the appropriate field (and possibly the others in the description). Don’t hesitate to be **as thorough as possible** and remember the basic rules of politeness. 😇 
 
@@ -32,4 +32,4 @@ Depending on the type of report selected, **different information will be reques
 
 A few days after your report—generally within a week—you should receive **a response via email** from Discord. Note that you will not be able to know the sanctions taken (or not) against the reported user. 😒
 
-[Screenshot of Discord response](../assets/discord-reply.png)
+[Screenshot of Discord response](../../../../en/docusaurus-plugin-content-docs/current/assets/discord-reply.png)

--- a/i18n/de/docusaurus-plugin-content-docs/current/language.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/language.md
@@ -23,7 +23,7 @@ If your server is set as a community server (Discord setting), RaidProtect will 
 - Select the “**Language**” button.
 - Choose the desired language.
 
-![Screenshot of language settings](./assets/rp-settings-language.webp)
+![Screenshot of language settings](../../../en/docusaurus-plugin-content-docs/current/assets/rp-settings-language.webp)
 
 Once the language is selected, the bot will automatically adapt all its messages, notifications, and commands to the chosen language for your server.
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/setup.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/setup.md
@@ -18,7 +18,7 @@ Allows you to enable or disable core features at a glance using an interactive s
 
 The bot will then send you a summary of the activated features and the changes it will make to the server.
 
-![Recommended configuration screenshot](./assets/rp-setup.webp)
+![Recommended configuration screenshot](../../../en/docusaurus-plugin-content-docs/current/assets/rp-setup.webp)
 
 <!--
 ### 🛠️ Advanced Configuration {#advanced}
@@ -42,14 +42,14 @@ The `/settings` command is the go-to command for managing your settings after in
 2. Easily navigate between different sections to find the settings you want to modify.
 3. Adjust the options: Each category presents a list of customizable options in the form of buttons or dropdown menus.
 
-![Settings screenshot](./assets/rp-settings.webp)
+![Settings screenshot](../../../en/docusaurus-plugin-content-docs/current/assets/rp-settings.webp)
 
 ### 🔄 Resetting a Setting {#reset}
 
 1. Navigate to the desired setting.
 2. Click on “**Reset**”.
 
-![Reset button screenshot](./assets/rp-button-reset.webp)
+![Reset button screenshot](../../../en/docusaurus-plugin-content-docs/current/assets/rp-button-reset.webp)
 
 The bot will confirm the reset before applying the changes.
 

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/features/anti-spam.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/features/anti-spam.md
@@ -14,7 +14,7 @@ Easily and effectively protect your Discord server with RaidProtect's anti-spam 
 
 **If spam is detected, RaidProtect kicks the spammer** and informs you via the logs channel. You can view details of the blocked spam by clicking on the provided link.
 
-![Spam Log Screenshot](../assets/log-spam-raidprotect.png)
+![Spam Log Screenshot](../../../../en/docusaurus-plugin-content-docs/version-3.0.0/assets/log-spam-raidprotect.png)
 
 ## 📈 Anti-Spam Security Levels {#level}
 

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/features/captcha.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/features/captcha.md
@@ -18,11 +18,11 @@ Users have five minutes to complete the captcha. After this time, they are kicke
 **The permissions for the "Unverified" role are managed automatically by RaidProtect.** While you can rename the role and channel, they must not be deleted.
 :::
 
-![How the Captcha Works](../assets/captcha-raidprotect.gif)
+![How the Captcha Works](../../../../en/docusaurus-plugin-content-docs/version-3.0.0/assets/captcha-raidprotect.gif)
 
 When a user joins your server with the captcha enabled, RaidProtect automatically posts **a message with the account creation date** of the new user in the logs channel.
 
-![Join Log Screenshot](../assets/log-join-captcha-raidprotect.png)
+![Join Log Screenshot](../../../../en/docusaurus-plugin-content-docs/version-3.0.0/assets/log-join-captcha-raidprotect.png)
 
 ## ⛽ Setting Up the Captcha {#setup}
 

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/features/others.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/features/others.md
@@ -14,7 +14,7 @@ Using these commands is **very straightforward**. For banning, simply run: `?ban
 
 For advanced users, note that you can ban a user even **if they are not on your server** by using their user ID. Convenient.
 
-![Ban Log Screenshot](../assets/log-ban-raidprotect.png)
+![Ban Log Screenshot](../../../../en/docusaurus-plugin-content-docs/version-3.0.0/assets/log-ban-raidprotect.png)
 
 Example of a log message after banning a user.
 
@@ -28,4 +28,4 @@ This command **removes the permission to speak** from the @everyone role in the 
 
 The final additional feature is the `?userinfo` command. This command primarily allows you to view **the account creation date of any user** and, if they are a server member, the date they joined your server. The command must be followed by a mention, a username with a tag, or a user ID. 👀  
 
-![User Info Screenshot](../assets/userinfo-raidprotect.png)
+![User Info Screenshot](../../../../en/docusaurus-plugin-content-docs/version-3.0.0/assets/userinfo-raidprotect.png)

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/features/raid-mode.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/features/raid-mode.md
@@ -10,7 +10,7 @@ Once Raid Mode is activated, all new users will be **instantly kicked**, and Rai
 
 **To activate Raid Mode,** a user with the permission to kick members must run the `?raidmode` command. A message will be posted in the logs to indicate its activation. Be aware that **Raid Mode does not deactivate automatically**, so remember to turn it off using the same command. 😇  
 
-![Raid Mode Activated Screenshot](../assets/raidmode-active-raidprotect.png)
+![Raid Mode Activated Screenshot](../../../../en/docusaurus-plugin-content-docs/version-3.0.0/assets/raidmode-active-raidprotect.png)
 
 ## 📡 Automatic Raid Mode
 
@@ -20,7 +20,7 @@ If a large number of users join your server within a very short period, RaidProt
 
 By default, Raid Mode is triggered if **more than 10 users join your server within 10 seconds.** If your server frequently receives a large influx of members simultaneously, it might be wise to adjust this setting to avoid false positives.
 
-![Automatic Raid Mode Screenshot](../assets/raidmode-auto-raidprotect.png)
+![Automatic Raid Mode Screenshot](../../../../en/docusaurus-plugin-content-docs/version-3.0.0/assets/raidmode-auto-raidprotect.png)
 
 The adjustable parameter is **the number of users allowed to join** within a 10-second timeframe before triggering Raid Mode. For example, by running the command:  
 `?settings autoraidmode 20`, Raid Mode will activate if more than 20 users join your server within 10 seconds. 🍃  

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/guides/report-violation-to-discord.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/guides/report-violation-to-discord.md
@@ -24,7 +24,7 @@ To make a report, you’ll need to provide evidence. Note that **screenshots are
 
 Reporting is quick and straightforward, taking only a few minutes. First, go to the **dedicated form** by visiting **[https://dis.gd/report](https://dis.gd/report)**.
 
-![Discord Report Form Screenshot](../assets/discord-report.png)
+![Discord Report Form Screenshot](../../../../en/docusaurus-plugin-content-docs/version-3.0.0/assets/discord-report.png)
 
 ### Submitting the Report to the Trust & Safety Team {#form}
 
@@ -34,4 +34,4 @@ Depending on the type of report, **different details will be required**. Paste t
 
 A few days after submitting your report—usually within a week—you should receive **an email response** from Discord. Note that you won’t be informed about the specific penalties (if any) imposed on the reported user. 😒  
 
-![Discord Reply Screenshot](../assets/discord-reply.png)
+![Discord Reply Screenshot](../../../../en/docusaurus-plugin-content-docs/version-3.0.0/assets/discord-reply.png)

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/malfunctions.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/malfunctions.md
@@ -60,4 +60,4 @@ The lock command is useful but has limitations. As noted in [this documentation]
 
 As a picture is worth a thousand words, here’s a visual example of what this looks like. 🔍  
 
-![Screenshot of channel lock configuration](./assets/lock-channel-messages-raidprotect.png)
+![Screenshot of channel lock configuration](../../../en/docusaurus-plugin-content-docs/version-3.0.0/assets/lock-channel-messages-raidprotect.png)

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/readme.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/readme.mdx
@@ -20,7 +20,7 @@ To ensure proper functionality, make sure to grant RaidProtect the **Administrat
 
 Also, make sure to **place its role at the same level as your server administrators** (see the image below). The permissions system prevents RaidProtect from taking action against users with a higher role.
 
-![Role Screenshot](./assets/role-raidprotect.png)
+![Role Screenshot](../../../en/docusaurus-plugin-content-docs/version-3.0.0/assets/role-raidprotect.png)
 :::
 
 That's it, **RaidProtect is now on your Discord server**! A channel named `#raidprotect-logs` has been created. Do not delete this channel—it is essential for the bot to function. If you already have a logs channel, you can change the RaidProtect logs channel with the command `?settings logs #new-channel`.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/features/anti-spam.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/features/anti-spam.md
@@ -37,7 +37,7 @@ You can exclude certain channels, roles, or even users from anti-spam monitoring
 - Role(s) to ignore
 - Member(s) to ignore
 
-![Anti-spam settings screenshot](../assets/rpBeta-settings-anti-spam.webp)
+![Anti-spam settings screenshot](../../../../en/docusaurus-plugin-content-docs/version-3.1.0/assets/rpBeta-settings-anti-spam.webp)
 
 :::info
 Channels containing “**spam**” in their name are automatically ignored. Users with administrator permissions are completely ignored.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/features/captcha.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/features/captcha.md
@@ -32,7 +32,7 @@ Setting up captcha is quick and easy.
 4. The **@Unverified** role is automatically created and configured.
 5. Configure the allowed number of attempts (between **1 and 3**) and the maximum resolution time (between **1 and 10 minutes**).
 
-![Captcha settings screenshot](../assets/rpBeta-settings-anti-captcha.webp)
+![Captcha settings screenshot](../../../../en/docusaurus-plugin-content-docs/version-3.1.0/assets/rpBeta-settings-anti-captcha.webp)
 
 ## ✨ Additional Features {#additional-features}
 

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/features/raid-mode.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/features/raid-mode.md
@@ -29,7 +29,7 @@ The `raidmode` command is [usable with a prefix](../guides/prefix.md).
 
 If your server frequently hosts many new members simultaneously, it is wise to adjust this threshold to avoid false positives.
 
-[Screenshot of automatic raid mode](../assets/rpBeta-settings-raid-mode.webp)
+[Screenshot of automatic raid mode](../../../../en/docusaurus-plugin-content-docs/version-3.1.0/assets/rpBeta-settings-raid-mode.webp)
 
 :::note
 We recommend entering a value between 10 and 20 members in 10 seconds for good system efficiency.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/features/reports.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/features/reports.md
@@ -32,7 +32,7 @@ Before the reporting system is fully operational, it is imperative to configure 
 4. Choose the desired channel (_e.g. #reports_).  
 If you do not have a suitable channel, you can opt to create one automatically using the **Create one for me** button.
 
-[Screenshot report settings](../assets/rpBeta-settings-reports.webp)
+[Screenshot report settings](../../../../en/docusaurus-plugin-content-docs/version-3.1.0/assets/rpBeta-settings-reports.webp)
 
 ### Configuring the Notification Role {#config-role}
 

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/guides/community.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/guides/community.md
@@ -29,7 +29,7 @@ If Community is already enabled on your server, the section will be called **Com
 4. **Complete the setup**
    - Click “Finish Setup”. The “Community” badge will appear on your server once activation is complete.
 
-![Discord Community activation screenshot](../assets/rp-enable-community.webp)
+![Discord Community activation screenshot](../../../../en/docusaurus-plugin-content-docs/version-3.1.0/assets/rp-enable-community.webp)
 
 ## 💡 Use DM Lock & Raid Mode modules after activation {#use}
 

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/guides/malfunctions.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/guides/malfunctions.md
@@ -58,4 +58,4 @@ This problem is relatively common, but it depends on **your server configuration
 
 The lock command seems magical, but it has its weaknesses. As [noted in this documentation](../features/channel-lock.md#lock), the command **only affects the @everyone role**. This means that if there is a role in the channel you want to lock that explicitly has permission to speak, they will still be able to do so. A picture is worth a thousand words, so here’s what that looks like in practice. 🔍 
 
-[Screenshot of channel lock configuration](../assets/lock-channel-messages-raidprotect.png)
+[Screenshot of channel lock configuration](../../../../en/docusaurus-plugin-content-docs/version-3.1.0/assets/lock-channel-messages-raidprotect.png)

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/guides/report-violation-to-discord.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/guides/report-violation-to-discord.md
@@ -24,7 +24,7 @@ To make a report, you need to provide evidence. First, note that **screenshots a
 
 Filing a report is very easy and takes only a few minutes. First, go to the **dedicated form** by following the link **https://dis.gd/report**.
 
-[Screenshot of Discord report](../assets/discord-report.png)
+[Screenshot of Discord report](../../../../en/docusaurus-plugin-content-docs/version-3.1.0/assets/discord-report.png)
 
 Depending on the type of report selected, **different information will be requested**. Enter the link to the message obtained in the previous step in the appropriate field (and possibly the others in the description). Don’t hesitate to be **as thorough as possible** and remember the basic rules of politeness. 😇 
 
@@ -32,4 +32,4 @@ Depending on the type of report selected, **different information will be reques
 
 A few days after your report—generally within a week—you should receive **a response via email** from Discord. Note that you will not be able to know the sanctions taken (or not) against the reported user. 😒
 
-[Screenshot of Discord response](../assets/discord-reply.png)
+[Screenshot of Discord response](../../../../en/docusaurus-plugin-content-docs/version-3.1.0/assets/discord-reply.png)

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/language.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/language.md
@@ -23,7 +23,7 @@ If your server is set as a community server (Discord setting), RaidProtect will 
 - Select the “**Language**” button.
 - Choose the desired language.
 
-![Screenshot of language settings](./assets/rpBeta-settings-language.webp)
+![Screenshot of language settings](../../../en/docusaurus-plugin-content-docs/version-3.1.0/assets/rpBeta-settings-language.webp)
 
 Once the language is selected, the bot will automatically adapt all its messages, notifications, and commands to the chosen language for your server.
 

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/setup.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/setup.md
@@ -39,7 +39,7 @@ The `/settings` command is the go-to command for managing your settings after in
 2. Easily navigate between different sections to find the settings you want to modify.
 3. Adjust the options: Each category presents a list of customizable options in the form of buttons or dropdown menus.
 
-![Settings Screenshot](./assets/rpBeta-settings.webp)
+![Settings Screenshot](../../../en/docusaurus-plugin-content-docs/version-3.1.0/assets/rpBeta-settings.webp)
 
 ### 🔄 Resetting a Setting {#reset}
 

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/features/anti-spam.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/features/anti-spam.md
@@ -21,7 +21,7 @@ RaidProtect offers three security levels to meet your server's needs.
 - 🟠 **Medium:** Sanctions all spam but respects ignored channels.
 - 🟢 **Low:** Sanctions only heavy spam.
 
-![Anti-spam settings screenshot](../assets/rp-settings-anti-spam.webp)
+![Anti-spam settings screenshot](../../../../en/docusaurus-plugin-content-docs/version-3.1.1/assets/rp-settings-anti-spam.webp)
 
 ### Changing the Security Level {#level}
 

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/features/captcha.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/features/captcha.md
@@ -32,7 +32,7 @@ Setting up captcha is quick and easy.
 4. The **@Unverified** role is automatically created and configured.
 5. Configure the allowed number of attempts (between **1 and 3**) and the maximum resolution time (between **1 and 10 minutes**).
 
-![Captcha settings screenshot](../assets/rp-settings-captcha.webp)
+![Captcha settings screenshot](../../../../en/docusaurus-plugin-content-docs/version-3.1.1/assets/rp-settings-captcha.webp)
 
 ## ✨ Additional Features {#additional-features}
 

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/features/raid-mode.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/features/raid-mode.md
@@ -29,7 +29,7 @@ The `raidmode` command is [usable with a prefix](../guides/prefix.md).
 
 If your server frequently hosts many new members simultaneously, it is wise to adjust this threshold to avoid false positives.
 
-[Screenshot of automatic raid mode](../assets/rp-settings-raid-mode.webp)
+[Screenshot of automatic raid mode](../../../../en/docusaurus-plugin-content-docs/version-3.1.1/assets/rp-settings-raid-mode.webp)
 
 :::note
 We recommend entering a value between 10 and 20 members in 10 seconds for good system efficiency.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/features/reports.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/features/reports.md
@@ -24,7 +24,7 @@ Replace `[@user]` with the desired user and `[reason]` with the reason for the i
 
 Before the reporting system is fully operational, it is imperative to configure a **report channel** where all reports will be sent. You need to set up a log or notification channel to receive alerts regarding reports.
 
-[Report settings screenshot](../assets/rp-settings-reports.webp)
+[Report settings screenshot](../../../../en/docusaurus-plugin-content-docs/version-3.1.1/assets/rp-settings-reports.webp)
 
 ### Setting Up the Channel {#config-channel}
 

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/features/tag-role.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/features/tag-role.md
@@ -21,7 +21,7 @@ Configuration takes just a few clicks:
 3. Select an existing role via the selector or click “**Create one for me**”.  
 4. You can deselect the role at any time by clicking on the “**Reset**” button.
 
-[Tag Role settings screenshot](../assets/rp-settings-tag-role.webp)
+[Tag Role settings screenshot](../../../../en/docusaurus-plugin-content-docs/version-3.1.1/assets/rp-settings-tag-role.webp)
 
 :::tip
 Members will receive the role the next time they update their profile (Username, Avatar, Banner, Roles, Tag…). You can [contact support](https://raidprotect.bot/discord) to request a full role sync if you have many members who currently have or previously had the Tag.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/guides/community.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/guides/community.md
@@ -29,7 +29,7 @@ If Community is already enabled on your server, the section will be called **Com
 4. **Complete the setup**
    - Click “Finish Setup”. The “Community” badge will appear on your server once activation is complete.
 
-![Discord Community activation screenshot](../assets/rp-enable-community.webp)
+![Discord Community activation screenshot](../../../../en/docusaurus-plugin-content-docs/version-3.1.1/assets/rp-enable-community.webp)
 
 ## 💡 Use DM Lock & Raid Mode modules after activation {#use}
 

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/guides/malfunctions.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/guides/malfunctions.md
@@ -58,4 +58,4 @@ This problem is relatively common, but it depends on **your server configuration
 
 The lock command seems magical, but it has its weaknesses. As [noted in this documentation](../features/channel-lock.md#lock), the command **only affects the @everyone role**. This means that if there is a role in the channel you want to lock that explicitly has permission to speak, they will still be able to do so. A picture is worth a thousand words, so here’s what that looks like in practice. 🔍 
 
-[Screenshot of channel lock configuration](../assets/lock-channel-messages-raidprotect.png)
+[Screenshot of channel lock configuration](../../../../en/docusaurus-plugin-content-docs/version-3.1.1/assets/lock-channel-messages-raidprotect.png)

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/guides/prefix.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/guides/prefix.md
@@ -24,7 +24,7 @@ If you prefer to use certain commands with a custom prefix, you can enable this 
 3. Enable or disable the prefix according to your preferences.
 If enabled, customize the prefix by entering the desired character or string.
 
-![Prefix settings screenshot](../assets/rp-settings-prefix.webp)
+![Prefix settings screenshot](../../../../en/docusaurus-plugin-content-docs/version-3.1.1/assets/rp-settings-prefix.webp)
 
 :::note
 Slash commands (`/`) remain available even if the prefix is activated.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/guides/report-violation-to-discord.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/guides/report-violation-to-discord.md
@@ -24,7 +24,7 @@ To make a report, you need to provide evidence. First, note that **screenshots a
 
 Filing a report is very easy and takes only a few minutes. First, go to the **dedicated form** by following the link **https://dis.gd/report**.
 
-[Screenshot of Discord report](../assets/discord-report.png)
+[Screenshot of Discord report](../../../../en/docusaurus-plugin-content-docs/version-3.1.1/assets/discord-report.png)
 
 Depending on the type of report selected, **different information will be requested**. Enter the link to the message obtained in the previous step in the appropriate field (and possibly the others in the description). Don’t hesitate to be **as thorough as possible** and remember the basic rules of politeness. 😇 
 
@@ -32,4 +32,4 @@ Depending on the type of report selected, **different information will be reques
 
 A few days after your report—generally within a week—you should receive **a response via email** from Discord. Note that you will not be able to know the sanctions taken (or not) against the reported user. 😒
 
-[Screenshot of Discord response](../assets/discord-reply.png)
+[Screenshot of Discord response](../../../../en/docusaurus-plugin-content-docs/version-3.1.1/assets/discord-reply.png)

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/language.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/language.md
@@ -23,7 +23,7 @@ If your server is set as a community server (Discord setting), RaidProtect will 
 - Select the “**Language**” button.
 - Choose the desired language.
 
-![Screenshot of language settings](./assets/rp-settings-language.webp)
+![Screenshot of language settings](../../../en/docusaurus-plugin-content-docs/version-3.1.1/assets/rp-settings-language.webp)
 
 Once the language is selected, the bot will automatically adapt all its messages, notifications, and commands to the chosen language for your server.
 

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/setup.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/setup.md
@@ -18,7 +18,7 @@ Allows you to enable or disable core features at a glance using an interactive s
 
 The bot will then send you a summary of the activated features and the changes it will make to the server.
 
-![Recommended configuration screenshot](./assets/rp-setup.webp)
+![Recommended configuration screenshot](../../../en/docusaurus-plugin-content-docs/version-3.1.1/assets/rp-setup.webp)
 
 <!--
 ### 🛠️ Advanced Configuration {#advanced}
@@ -42,14 +42,14 @@ The `/settings` command is the go-to command for managing your settings after in
 2. Easily navigate between different sections to find the settings you want to modify.
 3. Adjust the options: Each category presents a list of customizable options in the form of buttons or dropdown menus.
 
-![Settings screenshot](./assets/rp-settings.webp)
+![Settings screenshot](../../../en/docusaurus-plugin-content-docs/version-3.1.1/assets/rp-settings.webp)
 
 ### 🔄 Resetting a Setting {#reset}
 
 1. Navigate to the desired setting.
 2. Click on “**Reset**”.
 
-![Reset button screenshot](./assets/rp-button-reset.webp)
+![Reset button screenshot](../../../en/docusaurus-plugin-content-docs/version-3.1.1/assets/rp-button-reset.webp)
 
 The bot will confirm the reset before applying the changes.
 

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/features/anti-spam.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/features/anti-spam.mdx
@@ -25,7 +25,7 @@ RaidProtect offers three security levels to meet your server's needs.
 - 🟠 **Medium:** Sanctions all spam but respects ignored channels.
 - 🟢 **Low:** Sanctions only heavy spam.
 
-![Anti-spam settings screenshot](../assets/rp-settings-anti-spam.webp)
+![Anti-spam settings screenshot](../../../../en/docusaurus-plugin-content-docs/version-3.2.0/assets/rp-settings-anti-spam.webp)
 
 ### Changing the Security Level {#level}
 
@@ -76,7 +76,7 @@ Here are the different **available sanctions** as well as the **triggers** that 
 | Link spam                              | Mass sending of links                                   | 24 hours           |
 | Duplicate or heavy spam                | Copied messages or excessive spam                       | 24 hours           |
 
-![Screenshot of anti-spam sanctions](../assets/rp-settings-anti-spam-sanctions.webp)
+![Screenshot of anti-spam sanctions](../../../../en/docusaurus-plugin-content-docs/version-3.2.0/assets/rp-settings-anti-spam-sanctions.webp)
 
 ## 📑 Anti-spam Logs {#logs}
 
@@ -86,12 +86,12 @@ Detailed logs are generated with all messages deleted by the anti-spam. You can 
 <Tabs>
   <TabItem value="animator" label="Collapsed" default>
 
-![Screenshot of anti-spam logs](../assets/rp-logs-anti-spam.webp)
+![Screenshot of anti-spam logs](../../../../en/docusaurus-plugin-content-docs/version-3.2.0/assets/rp-logs-anti-spam.webp)
 
   </TabItem>
   <TabItem value="moderator" label="Expanded">
 
-![Screenshot of expanded anti-spam logs](../assets/rp-logs-anti-spam-expand.webp)
+![Screenshot of expanded anti-spam logs](../../../../en/docusaurus-plugin-content-docs/version-3.2.0/assets/rp-logs-anti-spam-expand.webp)
 
   </TabItem>
 </Tabs>

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/features/captcha.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/features/captcha.md
@@ -32,7 +32,7 @@ Setting up captcha is quick and easy.
 4. The **@Unverified** role is automatically created and configured.
 5. Configure the allowed number of attempts (between **1 and 3**) and the maximum resolution time (between **1 and 10 minutes**).
 
-![Captcha settings screenshot](../assets/rp-settings-captcha.webp)
+![Captcha settings screenshot](../../../../en/docusaurus-plugin-content-docs/version-3.2.0/assets/rp-settings-captcha.webp)
 
 ## ✨ Additional Features {#additional-features}
 

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/features/dm-lock.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/features/dm-lock.mdx
@@ -35,7 +35,7 @@ Discord’s community features are essential for DM Lock to function properly. [
 2. Click on the “**DM Lock**” button.
 3. Enable or disable automatic closing of direct messages.
 
-![DM Lock settings screenshot](../assets/rp-settings-dm-lock.webp)
+![DM Lock settings screenshot](../../../../en/docusaurus-plugin-content-docs/version-3.2.0/assets/rp-settings-dm-lock.webp)
 
 ## ℹ️ Command /dmlock-info {#info}
 
@@ -51,12 +51,12 @@ The `/dmlock-info` command informs members about the current **DM Lock** status 
 <Tabs>
   <TabItem value="enable" label="Enabled" default>
 
-![Screenshot of the dmlock-info command enabled](../assets/rp-dm-lock-info-enable.webp)
+![Screenshot of the dmlock-info command enabled](../../../../en/docusaurus-plugin-content-docs/version-3.2.0/assets/rp-dm-lock-info-enable.webp)
 
   </TabItem>
   <TabItem value="disable" label="Disabled">
 
-![Screenshot of the dmlock-info command disabled](../assets/rp-dm-lock-info-disable.webp)
+![Screenshot of the dmlock-info command disabled](../../../../en/docusaurus-plugin-content-docs/version-3.2.0/assets/rp-dm-lock-info-disable.webp)
 
   </TabItem>
 </Tabs>

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/features/raid-mode.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/features/raid-mode.md
@@ -31,7 +31,7 @@ The `raidmode` command is also [available with prefix](../guides/prefix.md).
 
 If your server often gets many new members at once, it’s wise to adjust this threshold to avoid false positives.
 
-![Screenshot of auto raid mode settings](../assets/rp-settings-raid-mode.webp)
+![Screenshot of auto raid mode settings](../../../../en/docusaurus-plugin-content-docs/version-3.2.0/assets/rp-settings-raid-mode.webp)
 
 :::note
 We recommend setting a value between 10 and 20 members in 10 seconds for optimal system performance.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/features/reports.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/features/reports.md
@@ -24,7 +24,7 @@ Replace `[@user]` with the desired user and `[reason]` with the reason for the i
 
 Before the reporting system is fully operational, it is imperative to configure a **report channel** where all reports will be sent. You need to set up a log or notification channel to receive alerts regarding reports.
 
-[Report settings screenshot](../assets/rp-settings-reports.webp)
+[Report settings screenshot](../../../../en/docusaurus-plugin-content-docs/version-3.2.0/assets/rp-settings-reports.webp)
 
 ### Setting Up the Channel {#config-channel}
 

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/features/tag-role.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/features/tag-role.md
@@ -21,7 +21,7 @@ Configuration takes just a few clicks:
 3. Select an existing role via the selector or click “**Create one for me**”.  
 4. You can deselect the role at any time by clicking on the “**Reset**” button.
 
-[Tag Role settings screenshot](../assets/rp-settings-tag-role.webp)
+[Tag Role settings screenshot](../../../../en/docusaurus-plugin-content-docs/version-3.2.0/assets/rp-settings-tag-role.webp)
 
 :::tip
 Members will receive the role the next time they update their profile (Username, Avatar, Banner, Roles, Tag…). You can [contact support](https://raidprotect.bot/discord) to request a full role sync if you have many members who currently have or previously had the Tag.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/guides/community.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/guides/community.md
@@ -29,7 +29,7 @@ If Community is already enabled on your server, the section will be called **Com
 4. **Complete the setup**
    - Click “Finish Setup”. The “Community” badge will appear on your server once activation is complete.
 
-![Discord Community activation screenshot](../assets/rp-enable-community.webp)
+![Discord Community activation screenshot](../../../../en/docusaurus-plugin-content-docs/version-3.2.0/assets/rp-enable-community.webp)
 
 ## 💡 Use DM Lock & Raid Mode modules after activation {#use}
 

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/guides/malfunctions.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/guides/malfunctions.md
@@ -58,4 +58,4 @@ This problem is relatively common, but it depends on **your server configuration
 
 The lock command seems magical, but it has its weaknesses. As [noted in this documentation](../features/channel-lock.md#lock), the command **only affects the @everyone role**. This means that if there is a role in the channel you want to lock that explicitly has permission to speak, they will still be able to do so. A picture is worth a thousand words, so here’s what that looks like in practice. 🔍 
 
-[Screenshot of channel lock configuration](../assets/lock-channel-messages-raidprotect.png)
+[Screenshot of channel lock configuration](../../../../en/docusaurus-plugin-content-docs/version-3.2.0/assets/lock-channel-messages-raidprotect.png)

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/guides/onboarding.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/guides/onboarding.md
@@ -4,7 +4,7 @@ title: Onboarding Process and Captcha
 
 If the `#verification` channel is not visible by default for new members, this can prevent the Captcha system from working properly. Here’s how to fix this issue step by step.
 
-![Captcha alert screenshot](../assets/rp-settings-captcha-alert.webp)
+![Captcha alert screenshot](../../../../en/docusaurus-plugin-content-docs/version-3.2.0/assets/rp-settings-captcha-alert.webp)
 
 ## 1️⃣ Check the channel permissions {#permissions}
 
@@ -13,7 +13,7 @@ If the `#verification` channel is not visible by default for new members, this c
    - Make sure `@everyone` **does not** have permission to view the channel.
    - Ensure the `@Unverified` role **has** permission to **view the channel**, **read message history**, and **send messages**.
 
-![Screenshot channel permissions check](../assets/rp-verification-channel-permissions.webp)
+![Screenshot channel permissions check](../../../../en/docusaurus-plugin-content-docs/version-3.2.0/assets/rp-verification-channel-permissions.webp)
 
 ## 2️⃣ Check the Welcome category {#default-category}
 
@@ -22,7 +22,7 @@ If the `#verification` channel is not visible by default for new members, this c
 3. If needed, move `#verification` into a checked category.
 4. Save the changes.
 
-![Screenshot welcome category check](../assets/rp-welcome-category.webp)
+![Screenshot welcome category check](../../../../en/docusaurus-plugin-content-docs/version-3.2.0/assets/rp-welcome-category.webp)
 
 ## 3️⃣ Refresh the configuration in RaidProtect {#refresh-config}
 

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/guides/prefix.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/guides/prefix.md
@@ -24,7 +24,7 @@ If you prefer to use certain commands with a custom prefix, you can enable this 
 3. Enable or disable the prefix according to your preferences.
 If enabled, customize the prefix by entering the desired character or string.
 
-![Prefix settings screenshot](../assets/rp-settings-prefix.webp)
+![Prefix settings screenshot](../../../../en/docusaurus-plugin-content-docs/version-3.2.0/assets/rp-settings-prefix.webp)
 
 :::note
 Slash commands (`/`) remain available even if the prefix is activated.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/guides/report-violation-to-discord.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/guides/report-violation-to-discord.md
@@ -24,7 +24,7 @@ To make a report, you need to provide evidence. First, note that **screenshots a
 
 Filing a report is very easy and takes only a few minutes. First, go to the **dedicated form** by following the link **https://dis.gd/report**.
 
-[Screenshot of Discord report](../assets/discord-report.png)
+[Screenshot of Discord report](../../../../en/docusaurus-plugin-content-docs/version-3.2.0/assets/discord-report.png)
 
 Depending on the type of report selected, **different information will be requested**. Enter the link to the message obtained in the previous step in the appropriate field (and possibly the others in the description). Don’t hesitate to be **as thorough as possible** and remember the basic rules of politeness. 😇 
 
@@ -32,4 +32,4 @@ Depending on the type of report selected, **different information will be reques
 
 A few days after your report—generally within a week—you should receive **a response via email** from Discord. Note that you will not be able to know the sanctions taken (or not) against the reported user. 😒
 
-[Screenshot of Discord response](../assets/discord-reply.png)
+[Screenshot of Discord response](../../../../en/docusaurus-plugin-content-docs/version-3.2.0/assets/discord-reply.png)

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/language.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/language.md
@@ -23,7 +23,7 @@ If your server is set as a community server (Discord setting), RaidProtect will 
 - Select the “**Language**” button.
 - Choose the desired language.
 
-![Screenshot of language settings](./assets/rp-settings-language.webp)
+![Screenshot of language settings](../../../en/docusaurus-plugin-content-docs/version-3.2.0/assets/rp-settings-language.webp)
 
 Once the language is selected, the bot will automatically adapt all its messages, notifications, and commands to the chosen language for your server.
 

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/setup.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/setup.md
@@ -18,7 +18,7 @@ Allows you to enable or disable core features at a glance using an interactive s
 
 The bot will then send you a summary of the activated features and the changes it will make to the server.
 
-![Recommended configuration screenshot](./assets/rp-setup.webp)
+![Recommended configuration screenshot](../../../en/docusaurus-plugin-content-docs/version-3.2.0/assets/rp-setup.webp)
 
 <!--
 ### 🛠️ Advanced Configuration {#advanced}
@@ -42,14 +42,14 @@ The `/settings` command is the go-to command for managing your settings after in
 2. Easily navigate between different sections to find the settings you want to modify.
 3. Adjust the options: Each category presents a list of customizable options in the form of buttons or dropdown menus.
 
-![Settings screenshot](./assets/rp-settings.webp)
+![Settings screenshot](../../../en/docusaurus-plugin-content-docs/version-3.2.0/assets/rp-settings.webp)
 
 ### 🔄 Resetting a Setting {#reset}
 
 1. Navigate to the desired setting.
 2. Click on “**Reset**”.
 
-![Reset button screenshot](./assets/rp-button-reset.webp)
+![Reset button screenshot](../../../en/docusaurus-plugin-content-docs/version-3.2.0/assets/rp-button-reset.webp)
 
 The bot will confirm the reset before applying the changes.
 


### PR DESCRIPTION
## Summary
- fix German blog image paths to reuse English assets
- fix German documentation image paths to reuse English assets

## Testing
- `npm run build` *(fails: docusaurus not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a8cba6a20832081ce69e426006f65