### PR TITLE
Fix untranslated alt texts in German docs

### DIFF
--- a/i18n/de/docusaurus-plugin-content-docs/current/features/dm-lock.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/features/dm-lock.mdx
@@ -51,12 +51,12 @@ Der Befehl `/dmlock-info` informiert Mitglieder über den aktuellen **DM Lock**-
 <Tabs>
   <TabItem value="enable" label="Aktiviert" default>
 
-![Screenshot of the dmlock-info command enabled](../../../../en/docusaurus-plugin-content-docs/current/assets/rp-dm-lock-info-enable.webp)
+![Screenshot des Befehls dmlock-info, aktiviert](../../../../en/docusaurus-plugin-content-docs/current/assets/rp-dm-lock-info-enable.webp)
 
   </TabItem>
   <TabItem value="disable" label="Deaktiviert">
 
-![Screenshot of the dmlock-info command disabled](../../../../en/docusaurus-plugin-content-docs/current/assets/rp-dm-lock-info-disable.webp)
+![Screenshot des Befehls dmlock-info, deaktiviert](../../../../en/docusaurus-plugin-content-docs/current/assets/rp-dm-lock-info-disable.webp)
 
   </TabItem>
 </Tabs>

--- a/i18n/de/docusaurus-plugin-content-docs/current/features/raid-mode.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/features/raid-mode.md
@@ -31,7 +31,7 @@ Der Befehl `raidmode` ist [auch mit Prefix verfügbar](../guides/prefix.md).
 
 Wenn auf deinem Server häufig viele Mitglieder gleichzeitig joinen, solltest du diese Schwelle anpassen, um Fehlalarme zu vermeiden.
 
-![Screenshot of auto raid mode settings](../../../../en/docusaurus-plugin-content-docs/current/assets/rp-settings-raid-mode.webp)
+![Screenshot der Einstellungen für den automatischen Raid-Modus](../../../../en/docusaurus-plugin-content-docs/current/assets/rp-settings-raid-mode.webp)
 
 :::note
 Wir empfehlen einen Wert zwischen 10 und 20 Mitgliedern in 10 Sekunden, um das System optimal zu nutzen.

--- a/i18n/de/docusaurus-plugin-content-docs/current/features/utilities.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/features/utilities.mdx
@@ -104,13 +104,13 @@ Bestimmte spezielle Kennzeichen (Flags) können für ein Mitglied angezeigt werd
 
 | **Flag**                                 | **Angezeigtes Emoji** | **Erläuterung** |
 | ---------------------------------------- | ----------------------------------------- | ------------------------------------------------ |
-| `DID_REJOIN`                             | <Icon src="/img/icons/MemberDidRejoin.svg" alt="icon MemberDidRejoin" title=":MemberDidRejoin:"/> | Der Nutzer hat den Server verlassen und ist wieder beigetreten. |
-| `IS_GUEST`                               | <Icon src="/img/icons/MemberIsGuest.svg" alt="icon MemberIsGuest" title=":MemberIsGuest:"/> | Gastmitglied (temporäre Einladung oder Gastzugang). |
-| `COMPLETED_ONBOARDING`                   | <Icon src="/img/icons/OnboardingCompleted.svg" alt="icon OnboardingCompleted" title=":OnboardingCompleted:"/> | Hat den Server-Onboarding-Prozess abgeschlossen. |
-| `STARTED_ONBOARDING`                     | <Icon src="/img/icons/OnboardingStarted.svg" alt="icon OnboardingStarted" title=":OnboardingStarted:"/> | Hat den Onboarding-Prozess gestartet. |
-| `COMPLETED_SERVER_GUIDE`                 | <Icon src="/img/icons/ServerGuideCompleted.svg" alt="icon ServerGuideCompleted" title=":ServerGuideCompleted:"/> | Hat den Server-Guide (falls aktiviert) abgeschlossen. |
-| `STARTED_SERVER_GUIDE`                   | <Icon src="/img/icons/ServerGuideStarted.svg" alt="icon ServerGuideStarted" title=":ServerGuideStarted:"/> | Hat den Server-Guide gestartet. |
-| `AUTOMOD_QUARANTINED_NAME`               | <Icon src="/img/icons/MemberQuarantined.svg" alt="icon MemberQuarantined" title=":MemberQuarantined:"/> | Durch Automoderation wegen des Benutzernamens unter Quarantäne gestellt. |
-| `AUTOMOD_QUARANTINED_GUILD_TAG`          | <Icon src="/img/icons/MemberQuarantined.svg" alt="icon MemberQuarantined" title=":MemberQuarantined:"/> | Durch Automoderation wegen Tag oder Nickname unter Quarantäne gestellt. |
-| `BYPASSES_VERIFICATION`                  | <Icon src="/img/icons/BypassVerification.svg" alt="icon BypassVerification" title=":BypassVerification:"/> | Nutzer kann die Server-Verifizierung umgehen. |
-| `SPAMMER`                                | <Icon src="/img/icons/UnusualAccountActivity.svg" alt="icon UnusualAccountActivity" title=":UnusualAccountActivity:"/> | Konto als Spammer markiert oder ungewöhnliche Aktivität festgestellt. |
+| `DID_REJOIN`                             | <Icon src="/img/icons/MemberDidRejoin.svg" alt="Icon MitgliedKamZurück" title=":MemberDidRejoin:"/> | Der Nutzer hat den Server verlassen und ist wieder beigetreten. |
+| `IS_GUEST`                               | <Icon src="/img/icons/MemberIsGuest.svg" alt="Icon MitgliedIstGast" title=":MemberIsGuest:"/> | Gastmitglied (temporäre Einladung oder Gastzugang). |
+| `COMPLETED_ONBOARDING`                   | <Icon src="/img/icons/OnboardingCompleted.svg" alt="Icon OnboardingAbgeschlossen" title=":OnboardingCompleted:"/> | Hat den Server-Onboarding-Prozess abgeschlossen. |
+| `STARTED_ONBOARDING`                     | <Icon src="/img/icons/OnboardingStarted.svg" alt="Icon OnboardingGestartet" title=":OnboardingStarted:"/> | Hat den Onboarding-Prozess gestartet. |
+| `COMPLETED_SERVER_GUIDE`                 | <Icon src="/img/icons/ServerGuideCompleted.svg" alt="Icon ServerGuideAbgeschlossen" title=":ServerGuideCompleted:"/> | Hat den Server-Guide (falls aktiviert) abgeschlossen. |
+| `STARTED_SERVER_GUIDE`                   | <Icon src="/img/icons/ServerGuideStarted.svg" alt="Icon ServerGuideGestartet" title=":ServerGuideStarted:"/> | Hat den Server-Guide gestartet. |
+| `AUTOMOD_QUARANTINED_NAME`               | <Icon src="/img/icons/MemberQuarantined.svg" alt="Icon MitgliedUnterQuarantäne" title=":MemberQuarantined:"/> | Durch Automoderation wegen des Benutzernamens unter Quarantäne gestellt. |
+| `AUTOMOD_QUARANTINED_GUILD_TAG`          | <Icon src="/img/icons/MemberQuarantined.svg" alt="Icon MitgliedUnterQuarantäne" title=":MemberQuarantined:"/> | Durch Automoderation wegen Tag oder Nickname unter Quarantäne gestellt. |
+| `BYPASSES_VERIFICATION`                  | <Icon src="/img/icons/BypassVerification.svg" alt="Icon VerifizierungUmgangen" title=":BypassVerification:"/> | Nutzer kann die Server-Verifizierung umgehen. |
+| `SPAMMER`                                | <Icon src="/img/icons/UnusualAccountActivity.svg" alt="Icon UngewöhnlicheKontoAktivität" title=":UnusualAccountActivity:"/> | Konto als Spammer markiert oder ungewöhnliche Aktivität festgestellt. |

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/malfunctions.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/malfunctions.md
@@ -49,4 +49,4 @@ Dieses Problem tritt relativ häufig auf, hängt jedoch von **deiner Serverkonfi
 
 Der Lock-Befehl wirkt zwar magisch, hat aber seine Schwächen. Wie [in der Dokumentation erwähnt](../features/channel-lock.md#lock), **betrifft der Befehl nur die @everyone-Rolle**. Wenn also eine Rolle im Kanal explizit die Berechtigung zum Schreiben hat, können Mitglieder mit dieser Rolle weiterhin schreiben. Ein Bild sagt mehr als tausend Worte, daher siehst du hier, wie das in der Praxis aussieht. 🔍
 
-![Screenshot of channel lock configuration](../../../../en/docusaurus-plugin-content-docs/current/assets/lock-channel-messages-raidprotect.png)
+![Screenshot der Kanalsperrkonfiguration](../../../../en/docusaurus-plugin-content-docs/current/assets/lock-channel-messages-raidprotect.png)

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/onboarding.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/onboarding.md
@@ -4,7 +4,7 @@ title: Onboarding-Prozess und Captcha
 
 Wenn der Kanal `#verification` für neue Mitglieder standardmäßig nicht sichtbar ist, kann das Captcha-System nicht korrekt funktionieren. So behebst du das Problem Schritt für Schritt.
 
-![Captcha alert screenshot](../../../../en/docusaurus-plugin-content-docs/current/assets/rp-settings-captcha-alert.webp)
+![Screenshot der Captcha-Warnung](../../../../en/docusaurus-plugin-content-docs/current/assets/rp-settings-captcha-alert.webp)
 
 ## 1️⃣ Kanalberechtigungen prüfen {#permissions}
 
@@ -13,7 +13,7 @@ Wenn der Kanal `#verification` für neue Mitglieder standardmäßig nicht sichtb
    - Stelle sicher, dass `@everyone` **keine** Berechtigung hat, den Kanal zu sehen.
    - Stelle sicher, dass die Rolle `@Unverified` **Berechtigung** hat, den Kanal zu **sehen**, **Nachrichtenverlauf zu lesen** und **Nachrichten zu senden**.
 
-![Screenshot channel permissions check](../../../../en/docusaurus-plugin-content-docs/current/assets/rp-verification-channel-permissions.webp)
+![Screenshot der Überprüfung der Kanalberechtigungen](../../../../en/docusaurus-plugin-content-docs/current/assets/rp-verification-channel-permissions.webp)
 
 ## 2️⃣ Willkommen-Kategorie prüfen {#default-category}
 
@@ -22,7 +22,7 @@ Wenn der Kanal `#verification` für neue Mitglieder standardmäßig nicht sichtb
 3. Verschiebe `#verification` gegebenenfalls in eine markierte Kategorie.
 4. Speichere die Änderungen.
 
-![Screenshot welcome category check](../../../../en/docusaurus-plugin-content-docs/current/assets/rp-welcome-category.webp)
+![Screenshot der Überprüfung der Willkommens-Kategorie](../../../../en/docusaurus-plugin-content-docs/current/assets/rp-welcome-category.webp)
 
 ## 3️⃣ Konfiguration in RaidProtect aktualisieren {#refresh-config}
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/report-violation-to-discord.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/report-violation-to-discord.md
@@ -24,7 +24,7 @@ Um eine Meldung einzureichen, benötigst du Beweise. Beachte zunächst, dass **S
 
 Eine Meldung zu erstellen ist ganz einfach und dauert nur wenige Minuten. Gehe zunächst auf das **dedizierte Formular** unter **https://dis.gd/report**.
 
-![Screenshot of Discord report](../../../../en/docusaurus-plugin-content-docs/current/assets/discord-report.png)
+![Screenshot des Discord-Meldeformulars](../../../../en/docusaurus-plugin-content-docs/current/assets/discord-report.png)
 
 Je nach ausgewähltem Meldetyp werden **unterschiedliche Informationen abgefragt**. Gib den im vorherigen Schritt kopierten Nachrichtenlink im entsprechenden Feld ein (weitere Links ggf. in der Beschreibung). Sei **so ausführlich wie möglich** und beachte die grundlegenden Höflichkeitsregeln. 😇
 
@@ -32,4 +32,4 @@ Je nach ausgewähltem Meldetyp werden **unterschiedliche Informationen abgefragt
 
 Einige Tage nach deiner Meldung – meist innerhalb einer Woche – solltest du **eine Antwort per E-Mail** von Discord erhalten. Beachte, dass du nicht erfährst, welche Sanktionen gegen den gemeldeten Nutzer ergriffen wurden (oder nicht). 😒
 
-![Screenshot of Discord response](../../../../en/docusaurus-plugin-content-docs/current/assets/discord-reply.png)
+![Screenshot der Antwort von Discord](../../../../en/docusaurus-plugin-content-docs/current/assets/discord-reply.png)

--- a/i18n/de/docusaurus-plugin-content-docs/current/language.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/language.md
@@ -23,7 +23,7 @@ Ist dein Server als Community-Server eingerichtet (Discord-Einstellung), verwend
 - Wähle die Schaltfläche "**Language**".
 - Entscheide dich für die gewünschte Sprache.
 
-![Screenshot of language settings](../../../en/docusaurus-plugin-content-docs/current/assets/rp-settings-language.webp)
+![Screenshot der Spracheinstellungen](../../../en/docusaurus-plugin-content-docs/current/assets/rp-settings-language.webp)
 
 Sobald die Sprache ausgewählt ist, passt der Bot automatisch alle seine Nachrichten, Benachrichtigungen und Befehle an die gewählte Sprache deines Servers an.
 


### PR DESCRIPTION
## Summary
- translate German docs alt texts for images and icons in features and guides

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_687b66b8365c8320b880e5e6e146384e