### PR TITLE
fix(broken-links): préfixer /docs/ sur DocCard hrefs + blog liens + #advanced

### DIFF
--- a/blog/3.1.0/3.1.0-interactions-update.md
+++ b/blog/3.1.0/3.1.0-interactions-update.md
@@ -29,7 +29,7 @@ Nous avons posé les bases d’un [**système multilingue**](/docs/language) et 
 
 ### Une commande de signalement {#report}
 
-Une fonctionnalité demandée depuis longtemps : [**un système de signalement**](/features/reports) permettant à votre communauté de rapporter facilement des incidents sur votre serveur.
+Une fonctionnalité demandée depuis longtemps : [**un système de signalement**](/docs/features/reports) permettant à votre communauté de rapporter facilement des incidents sur votre serveur.
 
 ![Capture d'écran menu de report](./assets/rp-report-message.webp)
 

--- a/blog/3.3.1/3.3.1-jail-and-mute.md
+++ b/blog/3.3.1/3.3.1-jail-and-mute.md
@@ -64,7 +64,7 @@ Ces langues viennent s'ajouter au français et à l'anglais déjà disponibles.
 
 ## ✨ Autres nouveautés de la 3.3.1 {#changelog}
 
-- **[Panneaux d'information](/features/display)** : Affichez des panneaux d'information dans vos salons avec `/display public`. RaidProtect génère des messages traduits dans toutes les langues supportées par Discord pour expliquer son fonctionnement à vos membres : signalements, accès aux sanctions, prison...
+- **[Panneaux d'information](/docs/features/display)** : Affichez des panneaux d'information dans vos salons avec `/display public`. RaidProtect génère des messages traduits dans toutes les langues supportées par Discord pour expliquer son fonctionnement à vos membres : signalements, accès aux sanctions, prison...
 - **[Blocage de membres](/docs/features/utilities#block)** : Bloquez l'accès de certains membres à des fonctionnalités spécifiques de RaidProtect avec [`/block add`](/docs/features/utilities#block-add), [`/block remove`](/docs/features/utilities#block-remove) et [`/block list`](/docs/features/utilities#block-list).
 - **[`/prune`](/docs/features/utilities#prune)** : Congédiez les membres inactifs avec des conditions plus précises.
 - **[`/channel clear`](/docs/features/utilities#channel-clear)** : Supprimez et recréez un salon en une commande.

--- a/docs/readme.mdx
+++ b/docs/readme.mdx
@@ -29,11 +29,11 @@ Afin d'assurer le bon fonctionnement de RaidProtect :
 
 Une fois RaidProtect ajouté à votre serveur, exécutez la commande [`/setup`](./setup.md#install).
 
-<DocCard item={{ type: 'link', href: '/beta/setup', docId: 'setup', label: 'Installation guidée' }} />
+<DocCard item={{ type: 'link', href: '/docs/beta/setup', docId: 'setup', label: 'Installation guidée' }} />
 <br />
 
 :::note
-Pour les moins téméraires (ou les plus pressés), vous pouvez simplement lire les indications de la [commande `/setup`](./setup.md#advanced) qui récapitule les principales informations de chaque fonctionnalités.
+Pour les moins téméraires (ou les plus pressés), vous pouvez simplement lire les indications de la [commande `/setup`](./setup.md#recommended) qui récapitule les principales informations de chaque fonctionnalités.
 :::
 
 ### Utilisation {#use}
@@ -44,11 +44,11 @@ Consultez les différentes sections de cette documentation pour découvrir toute
 Dans la documentation, les paramètres de commande sont affichés de cette manière lorsqu'elles sont `(obligatoires)` et lorsqu'elles sont `[facultatives]`.
 :::
 
-<DocCard item={{ type: 'link', href: '/beta/language', docId: 'language', label: 'Langues disponibles' }} />
+<DocCard item={{ type: 'link', href: '/docs/beta/language', docId: 'language', label: 'Langues disponibles' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/beta/features', label: 'Les fonctionnalités', description: 'Les documentations de chacune de nos fonctionnalités.' }} />
+<DocCard item={{ type: 'category', href: '/docs/beta/features', label: 'Les fonctionnalités', description: 'Les documentations de chacune de nos fonctionnalités.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/beta/guides', label: 'Nos guides', description: 'Des guides pour vous aider au mieux.' }} />
+<DocCard item={{ type: 'category', href: '/docs/beta/guides', label: 'Nos guides', description: 'Des guides pour vous aider au mieux.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/beta/useful-links', label: 'Liens utiles', description: 'Les divers liens utiles de RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/beta/useful-links', label: 'Liens utiles', description: 'Les divers liens utiles de RaidProtect.' }} />
 <br />

--- a/i18n/de/docusaurus-plugin-content-blog/3.1.0/3.1.0-interactions-update.md
+++ b/i18n/de/docusaurus-plugin-content-blog/3.1.0/3.1.0-interactions-update.md
@@ -31,7 +31,7 @@ Wir haben den Grundstein für ein [**mehrsprachiges System**](/docs/language) ge
 
 ### Ein Reporting‑Befehl {#report}
 
-Eine oft gewünschte Funktion: [**ein Meldesystem**](/features/reports), mit dem eure Community Vorfälle auf dem Server ganz einfach melden kann.
+Eine oft gewünschte Funktion: [**ein Meldesystem**](/docs/features/reports), mit dem eure Community Vorfälle auf dem Server ganz einfach melden kann.
 
 ![Screenshot of the report menu](../../../en/docusaurus-plugin-content-blog/3.1.0/assets/rp-report-message.webp)
 

--- a/i18n/de/docusaurus-plugin-content-blog/3.3.1/3.3.1-jail-and-mute.md
+++ b/i18n/de/docusaurus-plugin-content-blog/3.3.1/3.3.1-jail-and-mute.md
@@ -64,7 +64,7 @@ Diese Sprachen ergänzen Französisch und Englisch, die bereits verfügbar waren
 
 ## 📰 Informationstafeln {#display}
 
-Zeige [Informationstafeln](/features/display) in deinen Kanälen mit `/display public` an. RaidProtect generiert Nachrichten, die in alle von Discord unterstützten Sprachen übersetzt sind, um deinen Mitgliedern seine Funktionsweise zu erklären: Meldungen, Zugang zu Sanktionen, Gefängnis...
+Zeige [Informationstafeln](/docs/features/display) in deinen Kanälen mit `/display public` an. RaidProtect generiert Nachrichten, die in alle von Discord unterstützten Sprachen übersetzt sind, um deinen Mitgliedern seine Funktionsweise zu erklären: Meldungen, Zugang zu Sanktionen, Gefängnis...
 
 ---
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/readme.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/readme.mdx
@@ -29,11 +29,11 @@ Um das ordnungsgemäße Funktionieren von RaidProtect sicherzustellen:
 
 Sobald RaidProtect zu Ihrem Server hinzugefügt wurde, führen Sie den Befehl [`/setup`](./setup.md#install) aus.
 
-<DocCard item={{ type: 'link', href: '/beta/setup', docId: 'setup', label: 'Geführte Installation' }} />
+<DocCard item={{ type: 'link', href: '/docs/beta/setup', docId: 'setup', label: 'Geführte Installation' }} />
 <br />
 
 :::note
-Für die weniger Abenteuerlustigen (oder die Ungeduldigen) können Sie einfach die Anweisungen des [`/setup`-Befehls](./setup.md#advanced) lesen, der die wichtigsten Informationen jeder Funktion zusammenfasst.
+Für die weniger Abenteuerlustigen (oder die Ungeduldigen) können Sie einfach die Anweisungen des [`/setup`-Befehls](./setup.md#recommended) lesen, der die wichtigsten Informationen jeder Funktion zusammenfasst.
 :::
 
 ### Verwendung {#use}
@@ -44,11 +44,11 @@ Sehen Sie sich die verschiedenen Abschnitte dieser Dokumentation an, um alle Fun
 In der Dokumentation werden Befehlsparameter auf diese Weise angezeigt, wenn sie `(obligatorisch)` und wenn sie `[optional]` sind.
 :::
 
-<DocCard item={{ type: 'link', href: '/beta/language', docId: 'language', label: 'Verfügbare Sprachen' }} />
+<DocCard item={{ type: 'link', href: '/docs/beta/language', docId: 'language', label: 'Verfügbare Sprachen' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/beta/features', label: 'Funktionen', description: 'Dokumentation für jede unserer Funktionen.' }} />
+<DocCard item={{ type: 'category', href: '/docs/beta/features', label: 'Funktionen', description: 'Dokumentation für jede unserer Funktionen.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/beta/guides', label: 'Unsere Anleitungen', description: 'Anleitungen, die Ihnen bestmöglich helfen.' }} />
+<DocCard item={{ type: 'category', href: '/docs/beta/guides', label: 'Unsere Anleitungen', description: 'Anleitungen, die Ihnen bestmöglich helfen.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/beta/useful-links', label: 'Nützliche Links', description: 'Verschiedene nützliche Links zu RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/beta/useful-links', label: 'Nützliche Links', description: 'Verschiedene nützliche Links zu RaidProtect.' }} />
 <br />

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/readme.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.0.0/readme.mdx
@@ -31,18 +31,18 @@ That's it, **RaidProtect is now on your Discord server**! A channel named `#raid
 
 Check out the various sections of this documentation to **explore all the features offered** by the bot! 😎 
 
-<DocCard item={{ type: 'link', href: '/3.0.0/features/anti-spam', docId: 'features/anti-spam', label: 'Anti-Spam' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.0.0/features/anti-spam', docId: 'features/anti-spam', label: 'Anti-Spam' }} />
 <br />
-<DocCard item={{ type: 'link', href: '/3.0.0/features/captcha', docId: 'features/captcha', label: 'Captcha (Verification)' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.0.0/features/captcha', docId: 'features/captcha', label: 'Captcha (Verification)' }} />
 <br />
-<DocCard item={{ type: 'link', href: '/3.0.0/features/raid-mode', docId: 'features/raid-mode', label: 'Raid Mode' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.0.0/features/raid-mode', docId: 'features/raid-mode', label: 'Raid Mode' }} />
 <br />
-<DocCard item={{ type: 'link', href: '/3.0.0/features/others', docId: 'features/others', label: 'Others' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.0.0/features/others', docId: 'features/others', label: 'Others' }} />
 <br />
 
 For those in a hurry (or less adventurous), you can check out our quick guide, which summarizes the key information to get started. 😉 
 
-<DocCard item={{ type: 'link', href: '/3.0.0/quick-guide', docId: 'quick-guide', label: 'Quick Guide' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.0.0/quick-guide', docId: 'quick-guide', label: 'Quick Guide' }} />
 
 ## 👥 About the Project {#about}
 

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/readme.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.0/readme.mdx
@@ -29,22 +29,22 @@ To ensure the proper functioning of RaidProtect:
 
 Once RaidProtect is added to your server, run the [`/setup`](./setup.md#install) command.
 
-<DocCard item={{ type: 'link', href: '/3.1.0/setup', docId: 'setup', label: 'Guided Installation' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.1.0/setup', docId: 'setup', label: 'Guided Installation' }} />
 <br />
 
 :::note
-For the less adventurous (or the more impatient), you can simply read the instructions of the [`/setup`](./setup.md#advanced) command which summarizes the main information of each feature.
+For the less adventurous (or the more impatient), you can simply read the instructions of the [`/setup`](./setup.md#recommended) command which summarizes the main information of each feature.
 :::
 
 ### Usage {#use}
 
 Check out the different sections of this documentation to discover all the features offered by RaidProtect.
 
-<DocCard item={{ type: 'link', href: '/3.1.0/language', docId: 'language', label: 'Available Languages' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.1.0/language', docId: 'language', label: 'Available Languages' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.1.0/features', label: 'Features', description: 'Documentation for each of our features.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.1.0/features', label: 'Features', description: 'Documentation for each of our features.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.1.0/guides', label: 'Our Guides', description: 'Guides to help you the best way possible.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.1.0/guides', label: 'Our Guides', description: 'Guides to help you the best way possible.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.1.0/useful-links', label: 'Useful Links', description: 'Various useful links for RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.1.0/useful-links', label: 'Useful Links', description: 'Various useful links for RaidProtect.' }} />
 <br />

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/readme.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.1.1/readme.mdx
@@ -29,22 +29,22 @@ To ensure the proper functioning of RaidProtect:
 
 Once RaidProtect is added to your server, run the [`/setup`](./setup.md#install) command.
 
-<DocCard item={{ type: 'link', href: '/3.1.1/setup', docId: 'setup', label: 'Guided Installation' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.1.1/setup', docId: 'setup', label: 'Guided Installation' }} />
 <br />
 
 :::note
-For the less adventurous (or the more impatient), you can simply read the instructions of the [`/setup`](./setup.md#advanced) command which summarizes the main information of each feature.
+For the less adventurous (or the more impatient), you can simply read the instructions of the [`/setup`](./setup.md#recommended) command which summarizes the main information of each feature.
 :::
 
 ### Usage {#use}
 
 Check out the different sections of this documentation to discover all the features offered by RaidProtect.
 
-<DocCard item={{ type: 'link', href: '/3.1.1/language', docId: 'language', label: 'Available Languages' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.1.1/language', docId: 'language', label: 'Available Languages' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.1.1/features', label: 'Features', description: 'Documentation for each of our features.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.1.1/features', label: 'Features', description: 'Documentation for each of our features.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.1.1/guides', label: 'Our Guides', description: 'Guides to help you the best way possible.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.1.1/guides', label: 'Our Guides', description: 'Guides to help you the best way possible.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.1.1/useful-links', label: 'Useful Links', description: 'Various useful links for RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.1.1/useful-links', label: 'Useful Links', description: 'Various useful links for RaidProtect.' }} />
 <br />

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/readme.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.0/readme.mdx
@@ -29,22 +29,22 @@ Um das ordnungsgemäße Funktionieren von RaidProtect sicherzustellen:
 
 Sobald RaidProtect zu deinem Server hinzugefügt wurde, führe den Befehl [`/setup`](./setup.md#install) aus.
 
-<DocCard item={{ type: 'link', href: '/3.2.0/setup', docId: 'setup', label: 'Geführte Installation' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.2.0/setup', docId: 'setup', label: 'Geführte Installation' }} />
 <br />
 
 :::note
-Für die weniger Abenteuerlustigen (oder die Ungeduldigen) kannst du einfach die Anweisungen des Befehls [`/setup`](./setup.md#advanced) lesen, der die wichtigsten Informationen jeder Funktion zusammenfasst.
+Für die weniger Abenteuerlustigen (oder die Ungeduldigen) kannst du einfach die Anweisungen des Befehls [`/setup`](./setup.md#recommended) lesen, der die wichtigsten Informationen jeder Funktion zusammenfasst.
 :::
 
 ### Verwendung {#use}
 
 Sieh dir die verschiedenen Abschnitte dieser Dokumentation an, um alle Funktionen von RaidProtect zu entdecken.
 
-<DocCard item={{ type: 'link', href: '/3.2.0/language', docId: 'language', label: 'Verfügbare Sprachen' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.2.0/language', docId: 'language', label: 'Verfügbare Sprachen' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.2.0/features', label: 'Funktionen', description: 'Dokumentation für jede unserer Funktionen.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.2.0/features', label: 'Funktionen', description: 'Dokumentation für jede unserer Funktionen.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.2.0/guides', label: 'Unsere Anleitungen', description: 'Anleitungen, die dir bestmöglich helfen.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.2.0/guides', label: 'Unsere Anleitungen', description: 'Anleitungen, die dir bestmöglich helfen.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.2.0/useful-links', label: 'Nützliche Links', description: 'Verschiedene nützliche Links zu RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.2.0/useful-links', label: 'Nützliche Links', description: 'Verschiedene nützliche Links zu RaidProtect.' }} />
 <br />

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.2.1/readme.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.2.1/readme.mdx
@@ -29,11 +29,11 @@ Um das ordnungsgemäße Funktionieren von RaidProtect sicherzustellen:
 
 Sobald RaidProtect zu deinem Server hinzugefügt wurde, führe den Befehl [`/setup`](./setup.md#install) aus.
 
-<DocCard item={{ type: 'link', href: '/setup', docId: 'setup', label: 'Geführte Installation' }} />
+<DocCard item={{ type: 'link', href: '/docs/setup', docId: 'setup', label: 'Geführte Installation' }} />
 <br />
 
 :::note
-Für die weniger Abenteuerlustigen (oder die Ungeduldigen) kannst du einfach die Anweisungen des Befehls [`/setup`](./setup.md#advanced) lesen, der die wichtigsten Informationen jeder Funktion zusammenfasst.
+Für die weniger Abenteuerlustigen (oder die Ungeduldigen) kannst du einfach die Anweisungen des Befehls [`/setup`](./setup.md#recommended) lesen, der die wichtigsten Informationen jeder Funktion zusammenfasst.
 :::
 
 ### Verwendung {#use}
@@ -44,11 +44,11 @@ Sieh dir die verschiedenen Abschnitte dieser Dokumentation an, um alle Funktione
 In der Dokumentation werden Befehlsparameter auf diese Weise angezeigt, wenn sie `(obligatorisch)` und wenn sie `[optional]` sind.
 :::
 
-<DocCard item={{ type: 'link', href: '/language', docId: 'language', label: 'Verfügbare Sprachen' }} />
+<DocCard item={{ type: 'link', href: '/docs/language', docId: 'language', label: 'Verfügbare Sprachen' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/features', label: 'Funktionen', description: 'Dokumentation für jede unserer Funktionen.' }} />
+<DocCard item={{ type: 'category', href: '/docs/features', label: 'Funktionen', description: 'Dokumentation für jede unserer Funktionen.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/guides', label: 'Unsere Anleitungen', description: 'Anleitungen, die dir bestmöglich helfen.' }} />
+<DocCard item={{ type: 'category', href: '/docs/guides', label: 'Unsere Anleitungen', description: 'Anleitungen, die dir bestmöglich helfen.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/useful-links', label: 'Nützliche Links', description: 'Verschiedene nützliche Links zu RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/useful-links', label: 'Nützliche Links', description: 'Verschiedene nützliche Links zu RaidProtect.' }} />
 <br />

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.3.0/readme.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.3.0/readme.mdx
@@ -29,11 +29,11 @@ Um das ordnungsgemäße Funktionieren von RaidProtect sicherzustellen:
 
 Sobald RaidProtect zu deinem Server hinzugefügt wurde, führe den Befehl [`/setup`](./setup.md#install) aus.
 
-<DocCard item={{ type: 'link', href: '/3.3.0/setup', docId: 'setup', label: 'Geführte Installation' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.3.0/setup', docId: 'setup', label: 'Geführte Installation' }} />
 <br />
 
 :::note
-Für die weniger Abenteuerlustigen (oder die Ungeduldigen) kannst du einfach die Anweisungen des Befehls [`/setup`](./setup.md#advanced) lesen, der die wichtigsten Informationen jeder Funktion zusammenfasst.
+Für die weniger Abenteuerlustigen (oder die Ungeduldigen) kannst du einfach die Anweisungen des Befehls [`/setup`](./setup.md#recommended) lesen, der die wichtigsten Informationen jeder Funktion zusammenfasst.
 :::
 
 ### Verwendung {#use}
@@ -44,11 +44,11 @@ Sieh dir die verschiedenen Abschnitte dieser Dokumentation an, um alle Funktione
 In der Dokumentation werden Befehlsparameter auf diese Weise angezeigt, wenn sie `(obligatorisch)` und wenn sie `[optional]` sind.
 :::
 
-<DocCard item={{ type: 'link', href: '/3.3.0/language', docId: 'language', label: 'Verfügbare Sprachen' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.3.0/language', docId: 'language', label: 'Verfügbare Sprachen' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.0/features', label: 'Funktionen', description: 'Dokumentation für jede unserer Funktionen.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.0/features', label: 'Funktionen', description: 'Dokumentation für jede unserer Funktionen.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.0/guides', label: 'Unsere Anleitungen', description: 'Anleitungen, die dir bestmöglich helfen.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.0/guides', label: 'Unsere Anleitungen', description: 'Anleitungen, die dir bestmöglich helfen.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.0/useful-links', label: 'Nützliche Links', description: 'Verschiedene nützliche Links zu RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.0/useful-links', label: 'Nützliche Links', description: 'Verschiedene nützliche Links zu RaidProtect.' }} />
 <br />

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.3.1/readme.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.3.1/readme.mdx
@@ -29,11 +29,11 @@ Um das ordnungsgemäße Funktionieren von RaidProtect sicherzustellen:
 
 Sobald RaidProtect zu Ihrem Server hinzugefügt wurde, führen Sie den Befehl [`/setup`](./setup.md#install) aus.
 
-<DocCard item={{ type: 'link', href: '/3.3.1/setup', docId: 'setup', label: 'Geführte Installation' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.3.1/setup', docId: 'setup', label: 'Geführte Installation' }} />
 <br />
 
 :::note
-Für die weniger Abenteuerlustigen (oder die Ungeduldigen) können Sie einfach die Anweisungen des [`/setup`-Befehls](./setup.md#advanced) lesen, der die wichtigsten Informationen jeder Funktion zusammenfasst.
+Für die weniger Abenteuerlustigen (oder die Ungeduldigen) können Sie einfach die Anweisungen des [`/setup`-Befehls](./setup.md#recommended) lesen, der die wichtigsten Informationen jeder Funktion zusammenfasst.
 :::
 
 ### Verwendung {#use}
@@ -44,11 +44,11 @@ Sehen Sie sich die verschiedenen Abschnitte dieser Dokumentation an, um alle Fun
 In der Dokumentation werden Befehlsparameter auf diese Weise angezeigt, wenn sie `(obligatorisch)` und wenn sie `[optional]` sind.
 :::
 
-<DocCard item={{ type: 'link', href: '/3.3.1/language', docId: 'language', label: 'Verfügbare Sprachen' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.3.1/language', docId: 'language', label: 'Verfügbare Sprachen' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.1/features', label: 'Funktionen', description: 'Dokumentation für jede unserer Funktionen.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.1/features', label: 'Funktionen', description: 'Dokumentation für jede unserer Funktionen.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.1/guides', label: 'Unsere Anleitungen', description: 'Anleitungen, die Ihnen bestmöglich helfen.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.1/guides', label: 'Unsere Anleitungen', description: 'Anleitungen, die Ihnen bestmöglich helfen.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.1/useful-links', label: 'Nützliche Links', description: 'Verschiedene nützliche Links zu RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.1/useful-links', label: 'Nützliche Links', description: 'Verschiedene nützliche Links zu RaidProtect.' }} />
 <br />

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.3.2/readme.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.3.2/readme.mdx
@@ -29,11 +29,11 @@ Um das ordnungsgemäße Funktionieren von RaidProtect sicherzustellen:
 
 Sobald RaidProtect zu Ihrem Server hinzugefügt wurde, führen Sie den Befehl [`/setup`](./setup.md#install) aus.
 
-<DocCard item={{ type: 'link', href: '/3.3.2/setup', docId: 'setup', label: 'Geführte Installation' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.3.2/setup', docId: 'setup', label: 'Geführte Installation' }} />
 <br />
 
 :::note
-Für die weniger Abenteuerlustigen (oder die Ungeduldigen) können Sie einfach die Anweisungen des [`/setup`-Befehls](./setup.md#advanced) lesen, der die wichtigsten Informationen jeder Funktion zusammenfasst.
+Für die weniger Abenteuerlustigen (oder die Ungeduldigen) können Sie einfach die Anweisungen des [`/setup`-Befehls](./setup.md#recommended) lesen, der die wichtigsten Informationen jeder Funktion zusammenfasst.
 :::
 
 ### Verwendung {#use}
@@ -44,11 +44,11 @@ Sehen Sie sich die verschiedenen Abschnitte dieser Dokumentation an, um alle Fun
 In der Dokumentation werden Befehlsparameter auf diese Weise angezeigt, wenn sie `(obligatorisch)` und wenn sie `[optional]` sind.
 :::
 
-<DocCard item={{ type: 'link', href: '/3.3.2/language', docId: 'language', label: 'Verfügbare Sprachen' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.3.2/language', docId: 'language', label: 'Verfügbare Sprachen' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.2/features', label: 'Funktionen', description: 'Dokumentation für jede unserer Funktionen.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.2/features', label: 'Funktionen', description: 'Dokumentation für jede unserer Funktionen.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.2/guides', label: 'Unsere Anleitungen', description: 'Anleitungen, die Ihnen bestmöglich helfen.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.2/guides', label: 'Unsere Anleitungen', description: 'Anleitungen, die Ihnen bestmöglich helfen.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.2/useful-links', label: 'Nützliche Links', description: 'Verschiedene nützliche Links zu RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.2/useful-links', label: 'Nützliche Links', description: 'Verschiedene nützliche Links zu RaidProtect.' }} />
 <br />

--- a/i18n/de/docusaurus-plugin-content-docs/version-3.3.3/readme.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3.3.3/readme.mdx
@@ -29,11 +29,11 @@ Um das ordnungsgemäße Funktionieren von RaidProtect sicherzustellen:
 
 Sobald RaidProtect zu Ihrem Server hinzugefügt wurde, führen Sie den Befehl [`/setup`](./setup.md#install) aus.
 
-<DocCard item={{ type: 'link', href: '/setup', docId: 'setup', label: 'Geführte Installation' }} />
+<DocCard item={{ type: 'link', href: '/docs/setup', docId: 'setup', label: 'Geführte Installation' }} />
 <br />
 
 :::note
-Für die weniger Abenteuerlustigen (oder die Ungeduldigen) können Sie einfach die Anweisungen des [`/setup`-Befehls](./setup.md#advanced) lesen, der die wichtigsten Informationen jeder Funktion zusammenfasst.
+Für die weniger Abenteuerlustigen (oder die Ungeduldigen) können Sie einfach die Anweisungen des [`/setup`-Befehls](./setup.md#recommended) lesen, der die wichtigsten Informationen jeder Funktion zusammenfasst.
 :::
 
 ### Verwendung {#use}
@@ -44,11 +44,11 @@ Sehen Sie sich die verschiedenen Abschnitte dieser Dokumentation an, um alle Fun
 In der Dokumentation werden Befehlsparameter auf diese Weise angezeigt, wenn sie `(obligatorisch)` und wenn sie `[optional]` sind.
 :::
 
-<DocCard item={{ type: 'link', href: '/language', docId: 'language', label: 'Verfügbare Sprachen' }} />
+<DocCard item={{ type: 'link', href: '/docs/language', docId: 'language', label: 'Verfügbare Sprachen' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/features', label: 'Funktionen', description: 'Dokumentation für jede unserer Funktionen.' }} />
+<DocCard item={{ type: 'category', href: '/docs/features', label: 'Funktionen', description: 'Dokumentation für jede unserer Funktionen.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/guides', label: 'Unsere Anleitungen', description: 'Anleitungen, die Ihnen bestmöglich helfen.' }} />
+<DocCard item={{ type: 'category', href: '/docs/guides', label: 'Unsere Anleitungen', description: 'Anleitungen, die Ihnen bestmöglich helfen.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/useful-links', label: 'Nützliche Links', description: 'Verschiedene nützliche Links zu RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/useful-links', label: 'Nützliche Links', description: 'Verschiedene nützliche Links zu RaidProtect.' }} />
 <br />

--- a/i18n/en/docusaurus-plugin-content-blog/3.1.0/3.1.0-interactions-update.md
+++ b/i18n/en/docusaurus-plugin-content-blog/3.1.0/3.1.0-interactions-update.md
@@ -31,7 +31,7 @@ We’ve laid the groundwork for a [**multilingual system**](/docs/language) and 
 
 ### A Reporting Command {#report}
 
-A long-requested feature: [**a reporting system**](/features/reports) that allows your community to easily report incidents on your server.
+A long-requested feature: [**a reporting system**](/docs/features/reports) that allows your community to easily report incidents on your server.
 
 ![Screenshot of the report menu](./assets/rp-report-message.webp)
 

--- a/i18n/en/docusaurus-plugin-content-blog/3.3.1/3.3.1-jail-and-mute.md
+++ b/i18n/en/docusaurus-plugin-content-blog/3.3.1/3.3.1-jail-and-mute.md
@@ -64,7 +64,7 @@ These languages join French and English, which were already available.
 
 ## 📰 Information Panels {#display}
 
-Display [information panels](/features/display) in your channels with `/display public`. RaidProtect generates messages translated into all languages supported by Discord to explain how it works to your members: reports, sanctions access, jail...
+Display [information panels](/docs/features/display) in your channels with `/display public`. RaidProtect generates messages translated into all languages supported by Discord to explain how it works to your members: reports, sanctions access, jail...
 
 ---
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/readme.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/readme.mdx
@@ -29,11 +29,11 @@ To ensure the proper functioning of RaidProtect:
 
 Once RaidProtect is added to your server, run the [`/setup`](./setup.md#install) command.
 
-<DocCard item={{ type: 'link', href: '/beta/setup', docId: 'setup', label: 'Guided Installation' }} />
+<DocCard item={{ type: 'link', href: '/docs/beta/setup', docId: 'setup', label: 'Guided Installation' }} />
 <br />
 
 :::note
-For the less adventurous (or the more impatient), you can simply read the instructions of the [`/setup` command](./setup.md#advanced) which summarizes the main information of each feature.
+For the less adventurous (or the more impatient), you can simply read the instructions of the [`/setup` command](./setup.md#recommended) which summarizes the main information of each feature.
 :::
 
 ### Usage {#use}
@@ -44,11 +44,11 @@ Check out the different sections of this documentation to discover all the featu
 In the documentation, command parameters are displayed this way when they are `(mandatory)` and when they are `[optional]`.
 :::
 
-<DocCard item={{ type: 'link', href: '/beta/language', docId: 'language', label: 'Available Languages' }} />
+<DocCard item={{ type: 'link', href: '/docs/beta/language', docId: 'language', label: 'Available Languages' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/beta/features', label: 'Features', description: 'Documentation for each of our features.' }} />
+<DocCard item={{ type: 'category', href: '/docs/beta/features', label: 'Features', description: 'Documentation for each of our features.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/beta/guides', label: 'Our Guides', description: 'Guides to help you the best way possible.' }} />
+<DocCard item={{ type: 'category', href: '/docs/beta/guides', label: 'Our Guides', description: 'Guides to help you the best way possible.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/beta/useful-links', label: 'Useful Links', description: 'Various useful links for RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/beta/useful-links', label: 'Useful Links', description: 'Various useful links for RaidProtect.' }} />
 <br />

--- a/i18n/en/docusaurus-plugin-content-docs/version-3.0.0/readme.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/version-3.0.0/readme.mdx
@@ -31,18 +31,18 @@ That's it, **RaidProtect is now on your Discord server**! A channel named `#raid
 
 Check out the various sections of this documentation to **explore all the features offered** by the bot! 😎 
 
-<DocCard item={{ type: 'link', href: '/3.0.0/features/anti-spam', docId: 'features/anti-spam', label: 'Anti-Spam' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.0.0/features/anti-spam', docId: 'features/anti-spam', label: 'Anti-Spam' }} />
 <br />
-<DocCard item={{ type: 'link', href: '/3.0.0/features/captcha', docId: 'features/captcha', label: 'Captcha (Verification)' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.0.0/features/captcha', docId: 'features/captcha', label: 'Captcha (Verification)' }} />
 <br />
-<DocCard item={{ type: 'link', href: '/3.0.0/features/raid-mode', docId: 'features/raid-mode', label: 'Raid Mode' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.0.0/features/raid-mode', docId: 'features/raid-mode', label: 'Raid Mode' }} />
 <br />
-<DocCard item={{ type: 'link', href: '/3.0.0/features/others', docId: 'features/others', label: 'Others' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.0.0/features/others', docId: 'features/others', label: 'Others' }} />
 <br />
 
 For those in a hurry (or less adventurous), you can check out our quick guide, which summarizes the key information to get started. 😉 
 
-<DocCard item={{ type: 'link', href: '/3.0.0/quick-guide', docId: 'quick-guide', label: 'Quick Guide' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.0.0/quick-guide', docId: 'quick-guide', label: 'Quick Guide' }} />
 
 ## 👥 About the Project {#about}
 

--- a/i18n/en/docusaurus-plugin-content-docs/version-3.1.0/readme.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/version-3.1.0/readme.mdx
@@ -29,22 +29,22 @@ To ensure the proper functioning of RaidProtect:
 
 Once RaidProtect is added to your server, run the [`/setup`](./setup.md#install) command.
 
-<DocCard item={{ type: 'link', href: '/3.1.0/setup', docId: 'setup', label: 'Guided Installation' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.1.0/setup', docId: 'setup', label: 'Guided Installation' }} />
 <br />
 
 :::note
-For the less adventurous (or the more impatient), you can simply read the instructions of the [`/setup`](./setup.md#advanced) command which summarizes the main information of each feature.
+For the less adventurous (or the more impatient), you can simply read the instructions of the [`/setup`](./setup.md#recommended) command which summarizes the main information of each feature.
 :::
 
 ### Usage {#use}
 
 Check out the different sections of this documentation to discover all the features offered by RaidProtect.
 
-<DocCard item={{ type: 'link', href: '/3.1.0/language', docId: 'language', label: 'Available Languages' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.1.0/language', docId: 'language', label: 'Available Languages' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.1.0/features', label: 'Features', description: 'Documentation for each of our features.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.1.0/features', label: 'Features', description: 'Documentation for each of our features.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.1.0/guides', label: 'Our Guides', description: 'Guides to help you the best way possible.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.1.0/guides', label: 'Our Guides', description: 'Guides to help you the best way possible.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.1.0/useful-links', label: 'Useful Links', description: 'Various useful links for RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.1.0/useful-links', label: 'Useful Links', description: 'Various useful links for RaidProtect.' }} />
 <br />

--- a/i18n/en/docusaurus-plugin-content-docs/version-3.1.1/readme.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/version-3.1.1/readme.mdx
@@ -29,22 +29,22 @@ To ensure the proper functioning of RaidProtect:
 
 Once RaidProtect is added to your server, run the [`/setup`](./setup.md#install) command.
 
-<DocCard item={{ type: 'link', href: '/3.1.1/setup', docId: 'setup', label: 'Guided Installation' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.1.1/setup', docId: 'setup', label: 'Guided Installation' }} />
 <br />
 
 :::note
-For the less adventurous (or the more impatient), you can simply read the instructions of the [`/setup`](./setup.md#advanced) command which summarizes the main information of each feature.
+For the less adventurous (or the more impatient), you can simply read the instructions of the [`/setup`](./setup.md#recommended) command which summarizes the main information of each feature.
 :::
 
 ### Usage {#use}
 
 Check out the different sections of this documentation to discover all the features offered by RaidProtect.
 
-<DocCard item={{ type: 'link', href: '/3.1.1/language', docId: 'language', label: 'Available Languages' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.1.1/language', docId: 'language', label: 'Available Languages' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.1.1/features', label: 'Features', description: 'Documentation for each of our features.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.1.1/features', label: 'Features', description: 'Documentation for each of our features.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.1.1/guides', label: 'Our Guides', description: 'Guides to help you the best way possible.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.1.1/guides', label: 'Our Guides', description: 'Guides to help you the best way possible.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.1.1/useful-links', label: 'Useful Links', description: 'Various useful links for RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.1.1/useful-links', label: 'Useful Links', description: 'Various useful links for RaidProtect.' }} />
 <br />

--- a/i18n/en/docusaurus-plugin-content-docs/version-3.2.0/readme.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/version-3.2.0/readme.mdx
@@ -29,22 +29,22 @@ To ensure the proper functioning of RaidProtect:
 
 Once RaidProtect is added to your server, run the [`/setup`](./setup.md#install) command.
 
-<DocCard item={{ type: 'link', href: '/3.2.0/setup', docId: 'setup', label: 'Guided Installation' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.2.0/setup', docId: 'setup', label: 'Guided Installation' }} />
 <br />
 
 :::note
-For the less adventurous (or the more impatient), you can simply read the instructions of the [`/setup`](./setup.md#advanced) command which summarizes the main information of each feature.
+For the less adventurous (or the more impatient), you can simply read the instructions of the [`/setup`](./setup.md#recommended) command which summarizes the main information of each feature.
 :::
 
 ### Usage {#use}
 
 Check out the different sections of this documentation to discover all the features offered by RaidProtect.
 
-<DocCard item={{ type: 'link', href: '/3.2.0/language', docId: 'language', label: 'Available Languages' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.2.0/language', docId: 'language', label: 'Available Languages' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.2.0/features', label: 'Features', description: 'Documentation for each of our features.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.2.0/features', label: 'Features', description: 'Documentation for each of our features.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.2.0/guides', label: 'Our Guides', description: 'Guides to help you the best way possible.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.2.0/guides', label: 'Our Guides', description: 'Guides to help you the best way possible.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.2.0/useful-links', label: 'Useful Links', description: 'Various useful links for RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.2.0/useful-links', label: 'Useful Links', description: 'Various useful links for RaidProtect.' }} />
 <br />

--- a/i18n/en/docusaurus-plugin-content-docs/version-3.2.1/readme.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/version-3.2.1/readme.mdx
@@ -29,11 +29,11 @@ To ensure the proper functioning of RaidProtect:
 
 Once RaidProtect is added to your server, run the [`/setup`](./setup.md#install) command.
 
-<DocCard item={{ type: 'link', href: '/setup', docId: 'setup', label: 'Guided Installation' }} />
+<DocCard item={{ type: 'link', href: '/docs/setup', docId: 'setup', label: 'Guided Installation' }} />
 <br />
 
 :::note
-For the less adventurous (or the more impatient), you can simply read the instructions of the [`/setup`](./setup.md#advanced) command which summarizes the main information of each feature.
+For the less adventurous (or the more impatient), you can simply read the instructions of the [`/setup`](./setup.md#recommended) command which summarizes the main information of each feature.
 :::
 
 ### Usage {#use}
@@ -44,11 +44,11 @@ Check out the different sections of this documentation to discover all the featu
 In the documentation, command parameters are displayed this way when they are `(mandatory)` and when they are `[optional]`.
 :::
 
-<DocCard item={{ type: 'link', href: '/language', docId: 'language', label: 'Available Languages' }} />
+<DocCard item={{ type: 'link', href: '/docs/language', docId: 'language', label: 'Available Languages' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/features', label: 'Features', description: 'Documentation for each of our features.' }} />
+<DocCard item={{ type: 'category', href: '/docs/features', label: 'Features', description: 'Documentation for each of our features.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/guides', label: 'Our Guides', description: 'Guides to help you the best way possible.' }} />
+<DocCard item={{ type: 'category', href: '/docs/guides', label: 'Our Guides', description: 'Guides to help you the best way possible.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/useful-links', label: 'Useful Links', description: 'Various useful links for RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/useful-links', label: 'Useful Links', description: 'Various useful links for RaidProtect.' }} />
 <br />

--- a/i18n/en/docusaurus-plugin-content-docs/version-3.3.0/readme.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/version-3.3.0/readme.mdx
@@ -29,11 +29,11 @@ To ensure the proper functioning of RaidProtect:
 
 Once RaidProtect is added to your server, run the [`/setup`](./setup.md#install) command.
 
-<DocCard item={{ type: 'link', href: '/3.3.0/setup', docId: 'setup', label: 'Guided Installation' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.3.0/setup', docId: 'setup', label: 'Guided Installation' }} />
 <br />
 
 :::note
-For the less adventurous (or the more impatient), you can simply read the instructions of the [`/setup`](./setup.md#advanced) command which summarizes the main information of each feature.
+For the less adventurous (or the more impatient), you can simply read the instructions of the [`/setup`](./setup.md#recommended) command which summarizes the main information of each feature.
 :::
 
 ### Usage {#use}
@@ -44,11 +44,11 @@ Check out the different sections of this documentation to discover all the featu
 In the documentation, command parameters are displayed this way when they are `(mandatory)` and when they are `[optional]`.
 :::
 
-<DocCard item={{ type: 'link', href: '/3.3.0/language', docId: 'language', label: 'Available Languages' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.3.0/language', docId: 'language', label: 'Available Languages' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.0/features', label: 'Features', description: 'Documentation for each of our features.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.0/features', label: 'Features', description: 'Documentation for each of our features.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.0/guides', label: 'Our Guides', description: 'Guides to help you the best way possible.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.0/guides', label: 'Our Guides', description: 'Guides to help you the best way possible.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.0/useful-links', label: 'Useful Links', description: 'Various useful links for RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.0/useful-links', label: 'Useful Links', description: 'Various useful links for RaidProtect.' }} />
 <br />

--- a/i18n/en/docusaurus-plugin-content-docs/version-3.3.1/readme.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/version-3.3.1/readme.mdx
@@ -29,11 +29,11 @@ To ensure the proper functioning of RaidProtect:
 
 Once RaidProtect is added to your server, run the [`/setup`](./setup.md#install) command.
 
-<DocCard item={{ type: 'link', href: '/3.3.1/setup', docId: 'setup', label: 'Guided Installation' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.3.1/setup', docId: 'setup', label: 'Guided Installation' }} />
 <br />
 
 :::note
-For the less adventurous (or the more impatient), you can simply read the instructions of the [`/setup` command](./setup.md#advanced) which summarizes the main information of each feature.
+For the less adventurous (or the more impatient), you can simply read the instructions of the [`/setup` command](./setup.md#recommended) which summarizes the main information of each feature.
 :::
 
 ### Usage {#use}
@@ -44,11 +44,11 @@ Check out the different sections of this documentation to discover all the featu
 In the documentation, command parameters are displayed this way when they are `(mandatory)` and when they are `[optional]`.
 :::
 
-<DocCard item={{ type: 'link', href: '/3.3.1/language', docId: 'language', label: 'Available Languages' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.3.1/language', docId: 'language', label: 'Available Languages' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.1/features', label: 'Features', description: 'Documentation for each of our features.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.1/features', label: 'Features', description: 'Documentation for each of our features.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.1/guides', label: 'Our Guides', description: 'Guides to help you the best way possible.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.1/guides', label: 'Our Guides', description: 'Guides to help you the best way possible.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.1/useful-links', label: 'Useful Links', description: 'Various useful links for RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.1/useful-links', label: 'Useful Links', description: 'Various useful links for RaidProtect.' }} />
 <br />

--- a/i18n/en/docusaurus-plugin-content-docs/version-3.3.2/readme.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/version-3.3.2/readme.mdx
@@ -29,11 +29,11 @@ To ensure the proper functioning of RaidProtect:
 
 Once RaidProtect is added to your server, run the [`/setup`](./setup.md#install) command.
 
-<DocCard item={{ type: 'link', href: '/3.3.2/setup', docId: 'setup', label: 'Guided Installation' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.3.2/setup', docId: 'setup', label: 'Guided Installation' }} />
 <br />
 
 :::note
-For the less adventurous (or the more impatient), you can simply read the instructions of the [`/setup` command](./setup.md#advanced) which summarizes the main information of each feature.
+For the less adventurous (or the more impatient), you can simply read the instructions of the [`/setup` command](./setup.md#recommended) which summarizes the main information of each feature.
 :::
 
 ### Usage {#use}
@@ -44,11 +44,11 @@ Check out the different sections of this documentation to discover all the featu
 In the documentation, command parameters are displayed this way when they are `(mandatory)` and when they are `[optional]`.
 :::
 
-<DocCard item={{ type: 'link', href: '/3.3.2/language', docId: 'language', label: 'Available Languages' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.3.2/language', docId: 'language', label: 'Available Languages' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.2/features', label: 'Features', description: 'Documentation for each of our features.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.2/features', label: 'Features', description: 'Documentation for each of our features.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.2/guides', label: 'Our Guides', description: 'Guides to help you the best way possible.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.2/guides', label: 'Our Guides', description: 'Guides to help you the best way possible.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.2/useful-links', label: 'Useful Links', description: 'Various useful links for RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.2/useful-links', label: 'Useful Links', description: 'Various useful links for RaidProtect.' }} />
 <br />

--- a/i18n/en/docusaurus-plugin-content-docs/version-3.3.3/readme.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/version-3.3.3/readme.mdx
@@ -29,11 +29,11 @@ To ensure the proper functioning of RaidProtect:
 
 Once RaidProtect is added to your server, run the [`/setup`](./setup.md#install) command.
 
-<DocCard item={{ type: 'link', href: '/setup', docId: 'setup', label: 'Guided Installation' }} />
+<DocCard item={{ type: 'link', href: '/docs/setup', docId: 'setup', label: 'Guided Installation' }} />
 <br />
 
 :::note
-For the less adventurous (or the more impatient), you can simply read the instructions of the [`/setup` command](./setup.md#advanced) which summarizes the main information of each feature.
+For the less adventurous (or the more impatient), you can simply read the instructions of the [`/setup` command](./setup.md#recommended) which summarizes the main information of each feature.
 :::
 
 ### Usage {#use}
@@ -44,11 +44,11 @@ Check out the different sections of this documentation to discover all the featu
 In the documentation, command parameters are displayed this way when they are `(mandatory)` and when they are `[optional]`.
 :::
 
-<DocCard item={{ type: 'link', href: '/language', docId: 'language', label: 'Available Languages' }} />
+<DocCard item={{ type: 'link', href: '/docs/language', docId: 'language', label: 'Available Languages' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/features', label: 'Features', description: 'Documentation for each of our features.' }} />
+<DocCard item={{ type: 'category', href: '/docs/features', label: 'Features', description: 'Documentation for each of our features.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/guides', label: 'Our Guides', description: 'Guides to help you the best way possible.' }} />
+<DocCard item={{ type: 'category', href: '/docs/guides', label: 'Our Guides', description: 'Guides to help you the best way possible.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/useful-links', label: 'Useful Links', description: 'Various useful links for RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/useful-links', label: 'Useful Links', description: 'Various useful links for RaidProtect.' }} />
 <br />

--- a/i18n/es/docusaurus-plugin-content-blog/3.1.0/3.1.0-interactions-update.md
+++ b/i18n/es/docusaurus-plugin-content-blog/3.1.0/3.1.0-interactions-update.md
@@ -31,7 +31,7 @@ Hemos sentado las bases de un [**sistema multilingüe**](/docs/language) ¡y hem
 
 ### Un comando de reportes {#report}
 
-Una función muy solicitada: [**un sistema de reportes**](/features/reports) que permite a tu comunidad reportar fácilmente incidentes en tu servidor.
+Una función muy solicitada: [**un sistema de reportes**](/docs/features/reports) que permite a tu comunidad reportar fácilmente incidentes en tu servidor.
 
 ![Screenshot of the report menu](../../../en/docusaurus-plugin-content-blog/3.1.0/assets/rp-report-message.webp)
 

--- a/i18n/es/docusaurus-plugin-content-blog/3.3.1/3.3.1-jail-and-mute.md
+++ b/i18n/es/docusaurus-plugin-content-blog/3.3.1/3.3.1-jail-and-mute.md
@@ -64,7 +64,7 @@ Estos idiomas se suman al francés y al inglés ya disponibles.
 
 ## 📰 Paneles de información {#display}
 
-Muestra [paneles de información](/features/display) en tus canales con `/display public`. RaidProtect genera mensajes traducidos a todos los idiomas soportados por Discord para explicar su funcionamiento a tus miembros: reportes, acceso a sanciones, prisión...
+Muestra [paneles de información](/docs/features/display) en tus canales con `/display public`. RaidProtect genera mensajes traducidos a todos los idiomas soportados por Discord para explicar su funcionamiento a tus miembros: reportes, acceso a sanciones, prisión...
 
 ---
 

--- a/i18n/es/docusaurus-plugin-content-docs/current/readme.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/current/readme.mdx
@@ -29,11 +29,11 @@ Para asegurar el correcto funcionamiento de RaidProtect:
 
 Una vez que RaidProtect ha sido agregado a tu servidor, ejecuta el comando [`/setup`](./setup.md#install).
 
-<DocCard item={{ type: 'link', href: '/beta/setup', docId: 'setup', label: 'Instalacion guiada' }} />
+<DocCard item={{ type: 'link', href: '/docs/beta/setup', docId: 'setup', label: 'Instalacion guiada' }} />
 <br />
 
 :::note
-Para los menos aventureros (o los mas impacientes), simplemente pueden leer las instrucciones del [comando `/setup`](./setup.md#advanced) que resume la informacion principal de cada funcion.
+Para los menos aventureros (o los mas impacientes), simplemente pueden leer las instrucciones del [comando `/setup`](./setup.md#recommended) que resume la informacion principal de cada funcion.
 :::
 
 ### Uso {#use}
@@ -44,11 +44,11 @@ Consulta las diferentes secciones de esta documentacion para descubrir todas las
 En la documentacion, los parametros de los comandos se muestran de esta manera cuando son `(obligatorios)` y cuando son `[opcionales]`.
 :::
 
-<DocCard item={{ type: 'link', href: '/beta/language', docId: 'language', label: 'Idiomas disponibles' }} />
+<DocCard item={{ type: 'link', href: '/docs/beta/language', docId: 'language', label: 'Idiomas disponibles' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/beta/features', label: 'Funciones', description: 'Documentacion de cada una de nuestras funciones.' }} />
+<DocCard item={{ type: 'category', href: '/docs/beta/features', label: 'Funciones', description: 'Documentacion de cada una de nuestras funciones.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/beta/guides', label: 'Nuestras guias', description: 'Guias para ayudarte de la mejor manera posible.' }} />
+<DocCard item={{ type: 'category', href: '/docs/beta/guides', label: 'Nuestras guias', description: 'Guias para ayudarte de la mejor manera posible.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/beta/useful-links', label: 'Enlaces utiles', description: 'Diversos enlaces utiles para RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/beta/useful-links', label: 'Enlaces utiles', description: 'Diversos enlaces utiles para RaidProtect.' }} />
 <br />

--- a/i18n/es/docusaurus-plugin-content-docs/version-3.0.0/readme.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3.0.0/readme.mdx
@@ -31,18 +31,18 @@ Además, asegúrate de **colocar su rol al mismo nivel que los administradores d
 
 ¡Consulta las distintas secciones de esta documentación para **explorar todas las funciones que ofrece** el bot! 😎
 
-<DocCard item={{ type: 'link', href: '/3.0.0/features/anti-spam', docId: 'features/anti-spam', label: 'Anti-Spam' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.0.0/features/anti-spam', docId: 'features/anti-spam', label: 'Anti-Spam' }} />
 <br />
-<DocCard item={{ type: 'link', href: '/3.0.0/features/captcha', docId: 'features/captcha', label: 'Captcha (Verificación)' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.0.0/features/captcha', docId: 'features/captcha', label: 'Captcha (Verificación)' }} />
 <br />
-<DocCard item={{ type: 'link', href: '/3.0.0/features/raid-mode', docId: 'features/raid-mode', label: 'Modo Raid' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.0.0/features/raid-mode', docId: 'features/raid-mode', label: 'Modo Raid' }} />
 <br />
-<DocCard item={{ type: 'link', href: '/3.0.0/features/others', docId: 'features/others', label: 'Otros' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.0.0/features/others', docId: 'features/others', label: 'Otros' }} />
 <br />
 
 Para los que tienen prisa (o son menos aventureros), pueden consultar nuestra guía rápida, que resume la información clave para comenzar. 😉
 
-<DocCard item={{ type: 'link', href: '/3.0.0/quick-guide', docId: 'quick-guide', label: 'Guía rápida' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.0.0/quick-guide', docId: 'quick-guide', label: 'Guía rápida' }} />
 
 ## 👥 Acerca del proyecto {#about}
 

--- a/i18n/es/docusaurus-plugin-content-docs/version-3.1.0/readme.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3.1.0/readme.mdx
@@ -29,22 +29,22 @@ Para asegurar el correcto funcionamiento de RaidProtect:
 
 Una vez que RaidProtect se haya agregado a tu servidor, ejecuta el comando [`/setup`](./setup.md#install).
 
-<DocCard item={{ type: 'link', href: '/3.1.0/setup', docId: 'setup', label: 'Instalacion guiada' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.1.0/setup', docId: 'setup', label: 'Instalacion guiada' }} />
 <br />
 
 :::note
-Para los menos aventureros (o los mas impacientes), puedes simplemente leer las instrucciones del comando [`/setup`](./setup.md#advanced) que resume la informacion principal de cada funcion.
+Para los menos aventureros (o los mas impacientes), puedes simplemente leer las instrucciones del comando [`/setup`](./setup.md#recommended) que resume la informacion principal de cada funcion.
 :::
 
 ### Uso {#use}
 
 Consulta las diferentes secciones de esta documentacion para descubrir todas las funciones que ofrece RaidProtect.
 
-<DocCard item={{ type: 'link', href: '/3.1.0/language', docId: 'language', label: 'Idiomas disponibles' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.1.0/language', docId: 'language', label: 'Idiomas disponibles' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.1.0/features', label: 'Funciones', description: 'Documentacion de cada una de nuestras funciones.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.1.0/features', label: 'Funciones', description: 'Documentacion de cada una de nuestras funciones.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.1.0/guides', label: 'Nuestras guias', description: 'Guias para ayudarte de la mejor manera posible.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.1.0/guides', label: 'Nuestras guias', description: 'Guias para ayudarte de la mejor manera posible.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.1.0/useful-links', label: 'Enlaces utiles', description: 'Diversos enlaces utiles para RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.1.0/useful-links', label: 'Enlaces utiles', description: 'Diversos enlaces utiles para RaidProtect.' }} />
 <br />

--- a/i18n/es/docusaurus-plugin-content-docs/version-3.1.1/readme.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3.1.1/readme.mdx
@@ -29,22 +29,22 @@ Para asegurar el correcto funcionamiento de RaidProtect:
 
 Una vez que RaidProtect se haya agregado a tu servidor, ejecuta el comando [`/setup`](./setup.md#install).
 
-<DocCard item={{ type: 'link', href: '/3.1.1/setup', docId: 'setup', label: 'Instalacion Guiada' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.1.1/setup', docId: 'setup', label: 'Instalacion Guiada' }} />
 <br />
 
 :::note
-Para los menos aventureros (o los mas impacientes), simplemente puedes leer las instrucciones del comando [`/setup`](./setup.md#advanced) que resume la informacion principal de cada funcion.
+Para los menos aventureros (o los mas impacientes), simplemente puedes leer las instrucciones del comando [`/setup`](./setup.md#recommended) que resume la informacion principal de cada funcion.
 :::
 
 ### Uso {#use}
 
 Consulta las diferentes secciones de esta documentacion para descubrir todas las funciones que ofrece RaidProtect.
 
-<DocCard item={{ type: 'link', href: '/3.1.1/language', docId: 'language', label: 'Idiomas Disponibles' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.1.1/language', docId: 'language', label: 'Idiomas Disponibles' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.1.1/features', label: 'Funciones', description: 'Documentacion de cada una de nuestras funciones.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.1.1/features', label: 'Funciones', description: 'Documentacion de cada una de nuestras funciones.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.1.1/guides', label: 'Nuestras Guias', description: 'Guias para ayudarte de la mejor manera posible.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.1.1/guides', label: 'Nuestras Guias', description: 'Guias para ayudarte de la mejor manera posible.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.1.1/useful-links', label: 'Enlaces Utiles', description: 'Diversos enlaces utiles para RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.1.1/useful-links', label: 'Enlaces Utiles', description: 'Diversos enlaces utiles para RaidProtect.' }} />
 <br />

--- a/i18n/es/docusaurus-plugin-content-docs/version-3.2.0/readme.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3.2.0/readme.mdx
@@ -29,22 +29,22 @@ Para asegurar el correcto funcionamiento de RaidProtect:
 
 Una vez que RaidProtect esté añadido a tu servidor, ejecuta el comando [`/setup`](./setup.md#install).
 
-<DocCard item={{ type: 'link', href: '/3.2.0/setup', docId: 'setup', label: 'Instalación guiada' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.2.0/setup', docId: 'setup', label: 'Instalación guiada' }} />
 <br />
 
 :::note
-Para los menos aventureros (o los más impacientes), simplemente puedes leer las instrucciones del comando [`/setup`](./setup.md#advanced) que resume la información principal de cada función.
+Para los menos aventureros (o los más impacientes), simplemente puedes leer las instrucciones del comando [`/setup`](./setup.md#recommended) que resume la información principal de cada función.
 :::
 
 ### Uso {#use}
 
 Consulta las diferentes secciones de esta documentación para descubrir todas las funciones que ofrece RaidProtect.
 
-<DocCard item={{ type: 'link', href: '/3.2.0/language', docId: 'language', label: 'Idiomas disponibles' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.2.0/language', docId: 'language', label: 'Idiomas disponibles' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.2.0/features', label: 'Funciones', description: 'Documentación de cada una de nuestras funciones.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.2.0/features', label: 'Funciones', description: 'Documentación de cada una de nuestras funciones.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.2.0/guides', label: 'Nuestras guías', description: 'Guías para ayudarte de la mejor manera posible.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.2.0/guides', label: 'Nuestras guías', description: 'Guías para ayudarte de la mejor manera posible.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.2.0/useful-links', label: 'Enlaces útiles', description: 'Diversos enlaces útiles para RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.2.0/useful-links', label: 'Enlaces útiles', description: 'Diversos enlaces útiles para RaidProtect.' }} />
 <br />

--- a/i18n/es/docusaurus-plugin-content-docs/version-3.2.1/readme.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3.2.1/readme.mdx
@@ -29,11 +29,11 @@ Para asegurar el correcto funcionamiento de RaidProtect:
 
 Una vez que RaidProtect esté agregado a tu servidor, ejecuta el comando [`/setup`](./setup.md#install).
 
-<DocCard item={{ type: 'link', href: '/setup', docId: 'setup', label: 'Instalación guiada' }} />
+<DocCard item={{ type: 'link', href: '/docs/setup', docId: 'setup', label: 'Instalación guiada' }} />
 <br />
 
 :::note
-Para los menos aventureros (o los más impacientes), puedes simplemente leer las instrucciones del comando [`/setup`](./setup.md#advanced) que resume la información principal de cada función.
+Para los menos aventureros (o los más impacientes), puedes simplemente leer las instrucciones del comando [`/setup`](./setup.md#recommended) que resume la información principal de cada función.
 :::
 
 ### Uso {#use}
@@ -44,11 +44,11 @@ Consulta las diferentes secciones de esta documentación para descubrir todas la
 En la documentación, los parámetros de los comandos se muestran de esta manera cuando son `(obligatorios)` y cuando son `[opcionales]`.
 :::
 
-<DocCard item={{ type: 'link', href: '/language', docId: 'language', label: 'Idiomas disponibles' }} />
+<DocCard item={{ type: 'link', href: '/docs/language', docId: 'language', label: 'Idiomas disponibles' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/features', label: 'Funciones', description: 'Documentación de cada una de nuestras funciones.' }} />
+<DocCard item={{ type: 'category', href: '/docs/features', label: 'Funciones', description: 'Documentación de cada una de nuestras funciones.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/guides', label: 'Nuestras guías', description: 'Guías para ayudarte de la mejor manera posible.' }} />
+<DocCard item={{ type: 'category', href: '/docs/guides', label: 'Nuestras guías', description: 'Guías para ayudarte de la mejor manera posible.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/useful-links', label: 'Enlaces útiles', description: 'Diversos enlaces útiles para RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/useful-links', label: 'Enlaces útiles', description: 'Diversos enlaces útiles para RaidProtect.' }} />
 <br />

--- a/i18n/es/docusaurus-plugin-content-docs/version-3.3.0/readme.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3.3.0/readme.mdx
@@ -29,11 +29,11 @@ Para asegurar el correcto funcionamiento de RaidProtect:
 
 Una vez que RaidProtect se haya agregado a tu servidor, ejecuta el comando [`/setup`](./setup.md#install).
 
-<DocCard item={{ type: 'link', href: '/3.3.0/setup', docId: 'setup', label: 'Instalacion guiada' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.3.0/setup', docId: 'setup', label: 'Instalacion guiada' }} />
 <br />
 
 :::note
-Para los menos aventureros (o los mas impacientes), simplemente puedes leer las instrucciones del comando [`/setup`](./setup.md#advanced) que resume la informacion principal de cada funcion.
+Para los menos aventureros (o los mas impacientes), simplemente puedes leer las instrucciones del comando [`/setup`](./setup.md#recommended) que resume la informacion principal de cada funcion.
 :::
 
 ### Uso {#use}
@@ -44,11 +44,11 @@ Consulta las diferentes secciones de esta documentacion para descubrir todas las
 En la documentacion, los parametros de los comandos se muestran de esta manera cuando son `(obligatorios)` y cuando son `[opcionales]`.
 :::
 
-<DocCard item={{ type: 'link', href: '/3.3.0/language', docId: 'language', label: 'Idiomas disponibles' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.3.0/language', docId: 'language', label: 'Idiomas disponibles' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.0/features', label: 'Funciones', description: 'Documentacion de cada una de nuestras funciones.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.0/features', label: 'Funciones', description: 'Documentacion de cada una de nuestras funciones.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.0/guides', label: 'Nuestras guias', description: 'Guias para ayudarte de la mejor manera posible.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.0/guides', label: 'Nuestras guias', description: 'Guias para ayudarte de la mejor manera posible.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.0/useful-links', label: 'Enlaces utiles', description: 'Diversos enlaces utiles para RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.0/useful-links', label: 'Enlaces utiles', description: 'Diversos enlaces utiles para RaidProtect.' }} />
 <br />

--- a/i18n/es/docusaurus-plugin-content-docs/version-3.3.1/readme.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3.3.1/readme.mdx
@@ -29,11 +29,11 @@ Para asegurar el correcto funcionamiento de RaidProtect:
 
 Una vez que RaidProtect ha sido agregado a tu servidor, ejecuta el comando [`/setup`](./setup.md#install).
 
-<DocCard item={{ type: 'link', href: '/3.3.1/setup', docId: 'setup', label: 'Instalacion guiada' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.3.1/setup', docId: 'setup', label: 'Instalacion guiada' }} />
 <br />
 
 :::note
-Para los menos aventureros (o los mas impacientes), simplemente pueden leer las instrucciones del [comando `/setup`](./setup.md#advanced) que resume la informacion principal de cada funcion.
+Para los menos aventureros (o los mas impacientes), simplemente pueden leer las instrucciones del [comando `/setup`](./setup.md#recommended) que resume la informacion principal de cada funcion.
 :::
 
 ### Uso {#use}
@@ -44,11 +44,11 @@ Consulta las diferentes secciones de esta documentacion para descubrir todas las
 En la documentacion, los parametros de los comandos se muestran de esta manera cuando son `(obligatorios)` y cuando son `[opcionales]`.
 :::
 
-<DocCard item={{ type: 'link', href: '/3.3.1/language', docId: 'language', label: 'Idiomas disponibles' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.3.1/language', docId: 'language', label: 'Idiomas disponibles' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.1/features', label: 'Funciones', description: 'Documentacion de cada una de nuestras funciones.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.1/features', label: 'Funciones', description: 'Documentacion de cada una de nuestras funciones.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.1/guides', label: 'Nuestras guias', description: 'Guias para ayudarte de la mejor manera posible.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.1/guides', label: 'Nuestras guias', description: 'Guias para ayudarte de la mejor manera posible.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.1/useful-links', label: 'Enlaces utiles', description: 'Diversos enlaces utiles para RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.1/useful-links', label: 'Enlaces utiles', description: 'Diversos enlaces utiles para RaidProtect.' }} />
 <br />

--- a/i18n/es/docusaurus-plugin-content-docs/version-3.3.2/readme.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3.3.2/readme.mdx
@@ -29,11 +29,11 @@ Para asegurar el correcto funcionamiento de RaidProtect:
 
 Una vez que RaidProtect ha sido agregado a tu servidor, ejecuta el comando [`/setup`](./setup.md#install).
 
-<DocCard item={{ type: 'link', href: '/3.3.2/setup', docId: 'setup', label: 'Instalacion guiada' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.3.2/setup', docId: 'setup', label: 'Instalacion guiada' }} />
 <br />
 
 :::note
-Para los menos aventureros (o los mas impacientes), simplemente pueden leer las instrucciones del [comando `/setup`](./setup.md#advanced) que resume la informacion principal de cada funcion.
+Para los menos aventureros (o los mas impacientes), simplemente pueden leer las instrucciones del [comando `/setup`](./setup.md#recommended) que resume la informacion principal de cada funcion.
 :::
 
 ### Uso {#use}
@@ -44,11 +44,11 @@ Consulta las diferentes secciones de esta documentacion para descubrir todas las
 En la documentacion, los parametros de los comandos se muestran de esta manera cuando son `(obligatorios)` y cuando son `[opcionales]`.
 :::
 
-<DocCard item={{ type: 'link', href: '/3.3.2/language', docId: 'language', label: 'Idiomas disponibles' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.3.2/language', docId: 'language', label: 'Idiomas disponibles' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.2/features', label: 'Funciones', description: 'Documentacion de cada una de nuestras funciones.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.2/features', label: 'Funciones', description: 'Documentacion de cada una de nuestras funciones.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.2/guides', label: 'Nuestras guias', description: 'Guias para ayudarte de la mejor manera posible.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.2/guides', label: 'Nuestras guias', description: 'Guias para ayudarte de la mejor manera posible.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.2/useful-links', label: 'Enlaces utiles', description: 'Diversos enlaces utiles para RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.2/useful-links', label: 'Enlaces utiles', description: 'Diversos enlaces utiles para RaidProtect.' }} />
 <br />

--- a/i18n/es/docusaurus-plugin-content-docs/version-3.3.3/readme.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3.3.3/readme.mdx
@@ -29,11 +29,11 @@ Para asegurar el correcto funcionamiento de RaidProtect:
 
 Una vez que RaidProtect ha sido agregado a tu servidor, ejecuta el comando [`/setup`](./setup.md#install).
 
-<DocCard item={{ type: 'link', href: '/setup', docId: 'setup', label: 'Instalacion guiada' }} />
+<DocCard item={{ type: 'link', href: '/docs/setup', docId: 'setup', label: 'Instalacion guiada' }} />
 <br />
 
 :::note
-Para los menos aventureros (o los mas impacientes), simplemente pueden leer las instrucciones del [comando `/setup`](./setup.md#advanced) que resume la informacion principal de cada funcion.
+Para los menos aventureros (o los mas impacientes), simplemente pueden leer las instrucciones del [comando `/setup`](./setup.md#recommended) que resume la informacion principal de cada funcion.
 :::
 
 ### Uso {#use}
@@ -44,11 +44,11 @@ Consulta las diferentes secciones de esta documentacion para descubrir todas las
 En la documentacion, los parametros de los comandos se muestran de esta manera cuando son `(obligatorios)` y cuando son `[opcionales]`.
 :::
 
-<DocCard item={{ type: 'link', href: '/language', docId: 'language', label: 'Idiomas disponibles' }} />
+<DocCard item={{ type: 'link', href: '/docs/language', docId: 'language', label: 'Idiomas disponibles' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/features', label: 'Funciones', description: 'Documentacion de cada una de nuestras funciones.' }} />
+<DocCard item={{ type: 'category', href: '/docs/features', label: 'Funciones', description: 'Documentacion de cada una de nuestras funciones.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/guides', label: 'Nuestras guias', description: 'Guias para ayudarte de la mejor manera posible.' }} />
+<DocCard item={{ type: 'category', href: '/docs/guides', label: 'Nuestras guias', description: 'Guias para ayudarte de la mejor manera posible.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/useful-links', label: 'Enlaces utiles', description: 'Diversos enlaces utiles para RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/useful-links', label: 'Enlaces utiles', description: 'Diversos enlaces utiles para RaidProtect.' }} />
 <br />

--- a/i18n/pt/docusaurus-plugin-content-blog/3.1.0/3.1.0-interactions-update.md
+++ b/i18n/pt/docusaurus-plugin-content-blog/3.1.0/3.1.0-interactions-update.md
@@ -31,7 +31,7 @@ Lançámos as bases de um [**sistema multilingue**](/docs/language) e adicionám
 
 ### Um comando de denúncias {#report}
 
-Uma funcionalidade muito pedida: [**um sistema de denúncias**](/features/reports) que permite à tua comunidade reportar facilmente incidentes no teu servidor.
+Uma funcionalidade muito pedida: [**um sistema de denúncias**](/docs/features/reports) que permite à tua comunidade reportar facilmente incidentes no teu servidor.
 
 ![Screenshot of the report menu](../../../en/docusaurus-plugin-content-blog/3.1.0/assets/rp-report-message.webp)
 

--- a/i18n/pt/docusaurus-plugin-content-blog/3.3.1/3.3.1-jail-and-mute.md
+++ b/i18n/pt/docusaurus-plugin-content-blog/3.3.1/3.3.1-jail-and-mute.md
@@ -64,7 +64,7 @@ Estes idiomas juntam-se ao francês e ao inglês já disponíveis.
 
 ## 📰 Painéis de informação {#display}
 
-Apresenta [painéis de informação](/features/display) nos teus canais com `/display public`. O RaidProtect gera mensagens traduzidas em todos os idiomas suportados pelo Discord para explicar o seu funcionamento aos teus membros: denúncias, acesso a sanções, prisão...
+Apresenta [painéis de informação](/docs/features/display) nos teus canais com `/display public`. O RaidProtect gera mensagens traduzidas em todos os idiomas suportados pelo Discord para explicar o seu funcionamento aos teus membros: denúncias, acesso a sanções, prisão...
 
 ---
 

--- a/i18n/pt/docusaurus-plugin-content-docs/current/readme.mdx
+++ b/i18n/pt/docusaurus-plugin-content-docs/current/readme.mdx
@@ -29,11 +29,11 @@ Para garantir o bom funcionamento do RaidProtect:
 
 Assim que o RaidProtect for adicionado ao seu servidor, execute o comando [`/setup`](./setup.md#install).
 
-<DocCard item={{ type: 'link', href: '/beta/setup', docId: 'setup', label: 'Instalação Guiada' }} />
+<DocCard item={{ type: 'link', href: '/docs/beta/setup', docId: 'setup', label: 'Instalação Guiada' }} />
 <br />
 
 :::note
-Para os menos aventureiros (ou os mais impacientes), podem simplesmente ler as instruções do [comando `/setup`](./setup.md#advanced), que resume as principais informações de cada funcionalidade.
+Para os menos aventureiros (ou os mais impacientes), podem simplesmente ler as instruções do [comando `/setup`](./setup.md#recommended), que resume as principais informações de cada funcionalidade.
 :::
 
 ### Utilização {#use}
@@ -44,11 +44,11 @@ Consulte as diferentes secções desta documentação para descobrir todas as fu
 Na documentação, os parâmetros dos comandos são apresentados desta forma quando são `(obrigatórios)` e quando são `[opcionais]`.
 :::
 
-<DocCard item={{ type: 'link', href: '/beta/language', docId: 'language', label: 'Idiomas Disponíveis' }} />
+<DocCard item={{ type: 'link', href: '/docs/beta/language', docId: 'language', label: 'Idiomas Disponíveis' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/beta/features', label: 'Funcionalidades', description: 'Documentação de cada uma das nossas funcionalidades.' }} />
+<DocCard item={{ type: 'category', href: '/docs/beta/features', label: 'Funcionalidades', description: 'Documentação de cada uma das nossas funcionalidades.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/beta/guides', label: 'Os Nossos Guias', description: 'Guias para o ajudar da melhor forma possível.' }} />
+<DocCard item={{ type: 'category', href: '/docs/beta/guides', label: 'Os Nossos Guias', description: 'Guias para o ajudar da melhor forma possível.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/beta/useful-links', label: 'Links Úteis', description: 'Diversos links úteis para o RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/beta/useful-links', label: 'Links Úteis', description: 'Diversos links úteis para o RaidProtect.' }} />
 <br />

--- a/i18n/pt/docusaurus-plugin-content-docs/version-3.0.0/readme.mdx
+++ b/i18n/pt/docusaurus-plugin-content-docs/version-3.0.0/readme.mdx
@@ -31,18 +31,18 @@ Pronto, **o RaidProtect já está no seu servidor Discord**! Foi criado um canal
 
 Consulte as várias secções desta documentação para **explorar todas as funcionalidades oferecidas** pelo bot! 😎
 
-<DocCard item={{ type: 'link', href: '/3.0.0/features/anti-spam', docId: 'features/anti-spam', label: 'Anti-Spam' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.0.0/features/anti-spam', docId: 'features/anti-spam', label: 'Anti-Spam' }} />
 <br />
-<DocCard item={{ type: 'link', href: '/3.0.0/features/captcha', docId: 'features/captcha', label: 'Captcha (Verificação)' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.0.0/features/captcha', docId: 'features/captcha', label: 'Captcha (Verificação)' }} />
 <br />
-<DocCard item={{ type: 'link', href: '/3.0.0/features/raid-mode', docId: 'features/raid-mode', label: 'Modo Raid' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.0.0/features/raid-mode', docId: 'features/raid-mode', label: 'Modo Raid' }} />
 <br />
-<DocCard item={{ type: 'link', href: '/3.0.0/features/others', docId: 'features/others', label: 'Outros' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.0.0/features/others', docId: 'features/others', label: 'Outros' }} />
 <br />
 
 Para quem tem pressa (ou é menos aventureiro), pode consultar o nosso guia rápido, que resume as informações essenciais para começar. 😉
 
-<DocCard item={{ type: 'link', href: '/3.0.0/quick-guide', docId: 'quick-guide', label: 'Guia rápido' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.0.0/quick-guide', docId: 'quick-guide', label: 'Guia rápido' }} />
 
 ## 👥 Sobre o projeto {#about}
 

--- a/i18n/pt/docusaurus-plugin-content-docs/version-3.1.0/readme.mdx
+++ b/i18n/pt/docusaurus-plugin-content-docs/version-3.1.0/readme.mdx
@@ -29,22 +29,22 @@ Para garantir o bom funcionamento do RaidProtect:
 
 Apos o RaidProtect ter sido adicionado ao seu servidor, execute o comando [`/setup`](./setup.md#install).
 
-<DocCard item={{ type: 'link', href: '/3.1.0/setup', docId: 'setup', label: 'Instalacao guiada' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.1.0/setup', docId: 'setup', label: 'Instalacao guiada' }} />
 <br />
 
 :::note
-Para os menos aventureiros (ou os mais impacientes), pode simplesmente ler as instrucoes do comando [`/setup`](./setup.md#advanced) que resume as informacoes principais de cada funcionalidade.
+Para os menos aventureiros (ou os mais impacientes), pode simplesmente ler as instrucoes do comando [`/setup`](./setup.md#recommended) que resume as informacoes principais de cada funcionalidade.
 :::
 
 ### Utilizacao {#use}
 
 Consulte as diferentes seccoes desta documentacao para descobrir todas as funcionalidades oferecidas pelo RaidProtect.
 
-<DocCard item={{ type: 'link', href: '/3.1.0/language', docId: 'language', label: 'Idiomas disponiveis' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.1.0/language', docId: 'language', label: 'Idiomas disponiveis' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.1.0/features', label: 'Funcionalidades', description: 'Documentacao de cada uma das nossas funcionalidades.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.1.0/features', label: 'Funcionalidades', description: 'Documentacao de cada uma das nossas funcionalidades.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.1.0/guides', label: 'Os nossos guias', description: 'Guias para o ajudar da melhor forma possivel.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.1.0/guides', label: 'Os nossos guias', description: 'Guias para o ajudar da melhor forma possivel.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.1.0/useful-links', label: 'Links uteis', description: 'Diversos links uteis para o RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.1.0/useful-links', label: 'Links uteis', description: 'Diversos links uteis para o RaidProtect.' }} />
 <br />

--- a/i18n/pt/docusaurus-plugin-content-docs/version-3.1.1/readme.mdx
+++ b/i18n/pt/docusaurus-plugin-content-docs/version-3.1.1/readme.mdx
@@ -29,22 +29,22 @@ Para garantir o bom funcionamento do RaidProtect:
 
 Depois de o RaidProtect ser adicionado ao teu servidor, executa o comando [`/setup`](./setup.md#install).
 
-<DocCard item={{ type: 'link', href: '/3.1.1/setup', docId: 'setup', label: 'Instalacao Guiada' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.1.1/setup', docId: 'setup', label: 'Instalacao Guiada' }} />
 <br />
 
 :::note
-Para os menos aventureiros (ou os mais impacientes), podes simplesmente ler as instrucoes do comando [`/setup`](./setup.md#advanced) que resume as informacoes principais de cada funcionalidade.
+Para os menos aventureiros (ou os mais impacientes), podes simplesmente ler as instrucoes do comando [`/setup`](./setup.md#recommended) que resume as informacoes principais de cada funcionalidade.
 :::
 
 ### Utilizacao {#use}
 
 Consulta as diferentes secoes desta documentacao para descobrires todas as funcionalidades oferecidas pelo RaidProtect.
 
-<DocCard item={{ type: 'link', href: '/3.1.1/language', docId: 'language', label: 'Idiomas Disponiveis' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.1.1/language', docId: 'language', label: 'Idiomas Disponiveis' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.1.1/features', label: 'Funcionalidades', description: 'Documentacao de cada uma das nossas funcionalidades.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.1.1/features', label: 'Funcionalidades', description: 'Documentacao de cada uma das nossas funcionalidades.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.1.1/guides', label: 'Os Nossos Guias', description: 'Guias para te ajudar da melhor forma possivel.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.1.1/guides', label: 'Os Nossos Guias', description: 'Guias para te ajudar da melhor forma possivel.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.1.1/useful-links', label: 'Links Uteis', description: 'Diversos links uteis para o RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.1.1/useful-links', label: 'Links Uteis', description: 'Diversos links uteis para o RaidProtect.' }} />
 <br />

--- a/i18n/pt/docusaurus-plugin-content-docs/version-3.2.0/readme.mdx
+++ b/i18n/pt/docusaurus-plugin-content-docs/version-3.2.0/readme.mdx
@@ -29,22 +29,22 @@ Para garantir o correto funcionamento do RaidProtect:
 
 Assim que o RaidProtect estiver adicionado ao teu servidor, executa o comando [`/setup`](./setup.md#install).
 
-<DocCard item={{ type: 'link', href: '/3.2.0/setup', docId: 'setup', label: 'Instalacao guiada' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.2.0/setup', docId: 'setup', label: 'Instalacao guiada' }} />
 <br />
 
 :::note
-Para os menos aventureiros (ou os mais impacientes), podes simplesmente ler as instrucoes do comando [`/setup`](./setup.md#advanced) que resume as informacoes principais de cada funcionalidade.
+Para os menos aventureiros (ou os mais impacientes), podes simplesmente ler as instrucoes do comando [`/setup`](./setup.md#recommended) que resume as informacoes principais de cada funcionalidade.
 :::
 
 ### Utilizacao {#use}
 
 Consulta as diferentes seccoes desta documentacao para descobrir todas as funcionalidades oferecidas pelo RaidProtect.
 
-<DocCard item={{ type: 'link', href: '/3.2.0/language', docId: 'language', label: 'Idiomas disponiveis' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.2.0/language', docId: 'language', label: 'Idiomas disponiveis' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.2.0/features', label: 'Funcionalidades', description: 'Documentacao de cada uma das nossas funcionalidades.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.2.0/features', label: 'Funcionalidades', description: 'Documentacao de cada uma das nossas funcionalidades.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.2.0/guides', label: 'Os nossos guias', description: 'Guias para te ajudar da melhor forma possivel.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.2.0/guides', label: 'Os nossos guias', description: 'Guias para te ajudar da melhor forma possivel.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.2.0/useful-links', label: 'Links uteis', description: 'Diversos links uteis para o RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.2.0/useful-links', label: 'Links uteis', description: 'Diversos links uteis para o RaidProtect.' }} />
 <br />

--- a/i18n/pt/docusaurus-plugin-content-docs/version-3.2.1/readme.mdx
+++ b/i18n/pt/docusaurus-plugin-content-docs/version-3.2.1/readme.mdx
@@ -29,11 +29,11 @@ Para garantir o bom funcionamento do RaidProtect:
 
 Depois de o RaidProtect ser adicionado ao seu servidor, execute o comando [`/setup`](./setup.md#install).
 
-<DocCard item={{ type: 'link', href: '/setup', docId: 'setup', label: 'Instalação Guiada' }} />
+<DocCard item={{ type: 'link', href: '/docs/setup', docId: 'setup', label: 'Instalação Guiada' }} />
 <br />
 
 :::note
-Para os menos aventureiros (ou os mais impacientes), pode simplesmente ler as instruções do comando [`/setup`](./setup.md#advanced) que resume as principais informações de cada funcionalidade.
+Para os menos aventureiros (ou os mais impacientes), pode simplesmente ler as instruções do comando [`/setup`](./setup.md#recommended) que resume as principais informações de cada funcionalidade.
 :::
 
 ### Utilização {#use}
@@ -44,11 +44,11 @@ Consulte as diferentes secções desta documentação para descobrir todas as fu
 Na documentação, os parâmetros dos comandos são apresentados desta forma quando são `(obrigatórios)` e quando são `[opcionais]`.
 :::
 
-<DocCard item={{ type: 'link', href: '/language', docId: 'language', label: 'Idiomas Disponíveis' }} />
+<DocCard item={{ type: 'link', href: '/docs/language', docId: 'language', label: 'Idiomas Disponíveis' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/features', label: 'Funcionalidades', description: 'Documentação de cada uma das nossas funcionalidades.' }} />
+<DocCard item={{ type: 'category', href: '/docs/features', label: 'Funcionalidades', description: 'Documentação de cada uma das nossas funcionalidades.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/guides', label: 'Os Nossos Guias', description: 'Guias para o ajudar da melhor forma possível.' }} />
+<DocCard item={{ type: 'category', href: '/docs/guides', label: 'Os Nossos Guias', description: 'Guias para o ajudar da melhor forma possível.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/useful-links', label: 'Links Úteis', description: 'Diversos links úteis para o RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/useful-links', label: 'Links Úteis', description: 'Diversos links úteis para o RaidProtect.' }} />
 <br />

--- a/i18n/pt/docusaurus-plugin-content-docs/version-3.3.0/readme.mdx
+++ b/i18n/pt/docusaurus-plugin-content-docs/version-3.3.0/readme.mdx
@@ -29,11 +29,11 @@ Para garantir o bom funcionamento do RaidProtect:
 
 Assim que o RaidProtect for adicionado ao seu servidor, execute o comando [`/setup`](./setup.md#install).
 
-<DocCard item={{ type: 'link', href: '/3.3.0/setup', docId: 'setup', label: 'Instalacao Guiada' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.3.0/setup', docId: 'setup', label: 'Instalacao Guiada' }} />
 <br />
 
 :::note
-Para os menos aventureiros (ou os mais impacientes), pode simplesmente ler as instrucoes do comando [`/setup`](./setup.md#advanced) que resume as principais informacoes de cada funcionalidade.
+Para os menos aventureiros (ou os mais impacientes), pode simplesmente ler as instrucoes do comando [`/setup`](./setup.md#recommended) que resume as principais informacoes de cada funcionalidade.
 :::
 
 ### Utilizacao {#use}
@@ -44,11 +44,11 @@ Consulte as diferentes seccoes desta documentacao para descobrir todas as funcio
 Na documentacao, os parametros dos comandos sao apresentados desta forma quando sao `(obrigatorios)` e quando sao `[opcionais]`.
 :::
 
-<DocCard item={{ type: 'link', href: '/3.3.0/language', docId: 'language', label: 'Idiomas Disponiveis' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.3.0/language', docId: 'language', label: 'Idiomas Disponiveis' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.0/features', label: 'Funcionalidades', description: 'Documentacao de cada uma das nossas funcionalidades.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.0/features', label: 'Funcionalidades', description: 'Documentacao de cada uma das nossas funcionalidades.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.0/guides', label: 'Os Nossos Guias', description: 'Guias para o ajudar da melhor forma possivel.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.0/guides', label: 'Os Nossos Guias', description: 'Guias para o ajudar da melhor forma possivel.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.0/useful-links', label: 'Links Uteis', description: 'Diversos links uteis para o RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.0/useful-links', label: 'Links Uteis', description: 'Diversos links uteis para o RaidProtect.' }} />
 <br />

--- a/i18n/pt/docusaurus-plugin-content-docs/version-3.3.1/readme.mdx
+++ b/i18n/pt/docusaurus-plugin-content-docs/version-3.3.1/readme.mdx
@@ -29,11 +29,11 @@ Para garantir o bom funcionamento do RaidProtect:
 
 Assim que o RaidProtect for adicionado ao seu servidor, execute o comando [`/setup`](./setup.md#install).
 
-<DocCard item={{ type: 'link', href: '/3.3.1/setup', docId: 'setup', label: 'Instalação Guiada' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.3.1/setup', docId: 'setup', label: 'Instalação Guiada' }} />
 <br />
 
 :::note
-Para os menos aventureiros (ou os mais impacientes), podem simplesmente ler as instruções do [comando `/setup`](./setup.md#advanced), que resume as principais informações de cada funcionalidade.
+Para os menos aventureiros (ou os mais impacientes), podem simplesmente ler as instruções do [comando `/setup`](./setup.md#recommended), que resume as principais informações de cada funcionalidade.
 :::
 
 ### Utilização {#use}
@@ -44,11 +44,11 @@ Consulte as diferentes secções desta documentação para descobrir todas as fu
 Na documentação, os parâmetros dos comandos são apresentados desta forma quando são `(obrigatórios)` e quando são `[opcionais]`.
 :::
 
-<DocCard item={{ type: 'link', href: '/3.3.1/language', docId: 'language', label: 'Idiomas Disponíveis' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.3.1/language', docId: 'language', label: 'Idiomas Disponíveis' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.1/features', label: 'Funcionalidades', description: 'Documentação de cada uma das nossas funcionalidades.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.1/features', label: 'Funcionalidades', description: 'Documentação de cada uma das nossas funcionalidades.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.1/guides', label: 'Os Nossos Guias', description: 'Guias para o ajudar da melhor forma possível.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.1/guides', label: 'Os Nossos Guias', description: 'Guias para o ajudar da melhor forma possível.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.1/useful-links', label: 'Links Úteis', description: 'Diversos links úteis para o RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.1/useful-links', label: 'Links Úteis', description: 'Diversos links úteis para o RaidProtect.' }} />
 <br />

--- a/i18n/pt/docusaurus-plugin-content-docs/version-3.3.2/readme.mdx
+++ b/i18n/pt/docusaurus-plugin-content-docs/version-3.3.2/readme.mdx
@@ -29,11 +29,11 @@ Para garantir o bom funcionamento do RaidProtect:
 
 Assim que o RaidProtect for adicionado ao seu servidor, execute o comando [`/setup`](./setup.md#install).
 
-<DocCard item={{ type: 'link', href: '/3.3.2/setup', docId: 'setup', label: 'Instalação Guiada' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.3.2/setup', docId: 'setup', label: 'Instalação Guiada' }} />
 <br />
 
 :::note
-Para os menos aventureiros (ou os mais impacientes), podem simplesmente ler as instruções do [comando `/setup`](./setup.md#advanced), que resume as principais informações de cada funcionalidade.
+Para os menos aventureiros (ou os mais impacientes), podem simplesmente ler as instruções do [comando `/setup`](./setup.md#recommended), que resume as principais informações de cada funcionalidade.
 :::
 
 ### Utilização {#use}
@@ -44,11 +44,11 @@ Consulte as diferentes secções desta documentação para descobrir todas as fu
 Na documentação, os parâmetros dos comandos são apresentados desta forma quando são `(obrigatórios)` e quando são `[opcionais]`.
 :::
 
-<DocCard item={{ type: 'link', href: '/3.3.2/language', docId: 'language', label: 'Idiomas Disponíveis' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.3.2/language', docId: 'language', label: 'Idiomas Disponíveis' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.2/features', label: 'Funcionalidades', description: 'Documentação de cada uma das nossas funcionalidades.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.2/features', label: 'Funcionalidades', description: 'Documentação de cada uma das nossas funcionalidades.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.2/guides', label: 'Os Nossos Guias', description: 'Guias para o ajudar da melhor forma possível.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.2/guides', label: 'Os Nossos Guias', description: 'Guias para o ajudar da melhor forma possível.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.2/useful-links', label: 'Links Úteis', description: 'Diversos links úteis para o RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.2/useful-links', label: 'Links Úteis', description: 'Diversos links úteis para o RaidProtect.' }} />
 <br />

--- a/i18n/pt/docusaurus-plugin-content-docs/version-3.3.3/readme.mdx
+++ b/i18n/pt/docusaurus-plugin-content-docs/version-3.3.3/readme.mdx
@@ -29,11 +29,11 @@ Para garantir o bom funcionamento do RaidProtect:
 
 Assim que o RaidProtect for adicionado ao seu servidor, execute o comando [`/setup`](./setup.md#install).
 
-<DocCard item={{ type: 'link', href: '/setup', docId: 'setup', label: 'Instalação Guiada' }} />
+<DocCard item={{ type: 'link', href: '/docs/setup', docId: 'setup', label: 'Instalação Guiada' }} />
 <br />
 
 :::note
-Para os menos aventureiros (ou os mais impacientes), podem simplesmente ler as instruções do [comando `/setup`](./setup.md#advanced), que resume as principais informações de cada funcionalidade.
+Para os menos aventureiros (ou os mais impacientes), podem simplesmente ler as instruções do [comando `/setup`](./setup.md#recommended), que resume as principais informações de cada funcionalidade.
 :::
 
 ### Utilização {#use}
@@ -44,11 +44,11 @@ Consulte as diferentes secções desta documentação para descobrir todas as fu
 Na documentação, os parâmetros dos comandos são apresentados desta forma quando são `(obrigatórios)` e quando são `[opcionais]`.
 :::
 
-<DocCard item={{ type: 'link', href: '/language', docId: 'language', label: 'Idiomas Disponíveis' }} />
+<DocCard item={{ type: 'link', href: '/docs/language', docId: 'language', label: 'Idiomas Disponíveis' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/features', label: 'Funcionalidades', description: 'Documentação de cada uma das nossas funcionalidades.' }} />
+<DocCard item={{ type: 'category', href: '/docs/features', label: 'Funcionalidades', description: 'Documentação de cada uma das nossas funcionalidades.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/guides', label: 'Os Nossos Guias', description: 'Guias para o ajudar da melhor forma possível.' }} />
+<DocCard item={{ type: 'category', href: '/docs/guides', label: 'Os Nossos Guias', description: 'Guias para o ajudar da melhor forma possível.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/useful-links', label: 'Links Úteis', description: 'Diversos links úteis para o RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/useful-links', label: 'Links Úteis', description: 'Diversos links úteis para o RaidProtect.' }} />
 <br />

--- a/versioned_docs/version-3.0.0/readme.mdx
+++ b/versioned_docs/version-3.0.0/readme.mdx
@@ -32,18 +32,18 @@ N'oubliez pas également de **placer son rôle au niveau de celui des administra
 
 Consultez les différentes parties de cette documentation pour **découvrir toutes les fonctionnalités offertes** par le bot ! 😎 
 
-<DocCard item={{ type: 'link', href: '/3.0.0/features/anti-spam', docId: 'features/anti-spam', label: 'Anti-spam' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.0.0/features/anti-spam', docId: 'features/anti-spam', label: 'Anti-spam' }} />
 <br />
-<DocCard item={{ type: 'link', href: '/3.0.0/features/captcha', docId: 'features/captcha', label: 'Captcha (vérification)' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.0.0/features/captcha', docId: 'features/captcha', label: 'Captcha (vérification)' }} />
 <br />
-<DocCard item={{ type: 'link', href: '/3.0.0/features/raid-mode', docId: 'features/raid-mode', label: 'Mode raid' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.0.0/features/raid-mode', docId: 'features/raid-mode', label: 'Mode raid' }} />
 <br />
-<DocCard item={{ type: 'link', href: '/3.0.0/features/others', docId: 'features/others', label: 'Autres' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.0.0/features/others', docId: 'features/others', label: 'Autres' }} />
 <br />
 
 Pour les moins téméraires (ou les plus pressés), vous pouvez consulter notre guide rapide qui récapitule les principales informations à savoir pour débuter. 😉 
 
-<DocCard item={{ type: 'link', href: '/3.0.0/quick-guide', docId: 'quick-guide', label: 'Guide rapide' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.0.0/quick-guide', docId: 'quick-guide', label: 'Guide rapide' }} />
 
 ## 👥 À propos du projet {#about}
 

--- a/versioned_docs/version-3.1.0/readme.mdx
+++ b/versioned_docs/version-3.1.0/readme.mdx
@@ -29,22 +29,22 @@ Afin d'assurer le bon fonctionnement de RaidProtect :
 
 Une fois RaidProtect ajouté à votre serveur, exécutez la commande [`/setup`](./setup.md#install).
 
-<DocCard item={{ type: 'link', href: '/3.1.0/setup', docId: 'setup', label: 'Installation guidée' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.1.0/setup', docId: 'setup', label: 'Installation guidée' }} />
 <br />
 
 :::note
-Pour les moins téméraires (ou les plus pressés), vous pouvez simplement lire les indications de la [commande `/setup`](./setup.md#advanced) qui récapitule les principales informations de chaque fonctionnalités.
+Pour les moins téméraires (ou les plus pressés), vous pouvez simplement lire les indications de la [commande `/setup`](./setup.md#recommended) qui récapitule les principales informations de chaque fonctionnalités.
 :::
 
 ### Utilisation {#use}
 
 Consultez les différentes sections de cette documentation pour découvrir toutes les fonctionnalités offertes par RaidProtect.
 
-<DocCard item={{ type: 'link', href: '/3.1.0/language', docId: 'language', label: 'Langues disponibles' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.1.0/language', docId: 'language', label: 'Langues disponibles' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.1.0/features', label: 'Les fonctionnalités', description: 'Les documentations de chacune de nos fonctionnalités.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.1.0/features', label: 'Les fonctionnalités', description: 'Les documentations de chacune de nos fonctionnalités.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.1.0/guides', label: 'Nos guides', description: 'Des guides pour vous aider au mieux.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.1.0/guides', label: 'Nos guides', description: 'Des guides pour vous aider au mieux.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.1.0/useful-links', label: 'Liens utiles', description: 'Les divers liens utiles de RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.1.0/useful-links', label: 'Liens utiles', description: 'Les divers liens utiles de RaidProtect.' }} />
 <br />

--- a/versioned_docs/version-3.1.1/readme.mdx
+++ b/versioned_docs/version-3.1.1/readme.mdx
@@ -29,22 +29,22 @@ Afin d'assurer le bon fonctionnement de RaidProtect :
 
 Une fois RaidProtect ajouté à votre serveur, exécutez la commande [`/setup`](./setup.md#install).
 
-<DocCard item={{ type: 'link', href: '/3.1.1/setup', docId: 'setup', label: 'Installation guidée' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.1.1/setup', docId: 'setup', label: 'Installation guidée' }} />
 <br />
 
 :::note
-Pour les moins téméraires (ou les plus pressés), vous pouvez simplement lire les indications de la [commande `/setup`](./setup.md#advanced) qui récapitule les principales informations de chaque fonctionnalités.
+Pour les moins téméraires (ou les plus pressés), vous pouvez simplement lire les indications de la [commande `/setup`](./setup.md#recommended) qui récapitule les principales informations de chaque fonctionnalités.
 :::
 
 ### Utilisation {#use}
 
 Consultez les différentes sections de cette documentation pour découvrir toutes les fonctionnalités offertes par RaidProtect.
 
-<DocCard item={{ type: 'link', href: '/3.1.1/language', docId: 'language', label: 'Langues disponibles' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.1.1/language', docId: 'language', label: 'Langues disponibles' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.1.1/features', label: 'Les fonctionnalités', description: 'Les documentations de chacune de nos fonctionnalités.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.1.1/features', label: 'Les fonctionnalités', description: 'Les documentations de chacune de nos fonctionnalités.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.1.1/guides', label: 'Nos guides', description: 'Des guides pour vous aider au mieux.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.1.1/guides', label: 'Nos guides', description: 'Des guides pour vous aider au mieux.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.1.1/useful-links', label: 'Liens utiles', description: 'Les divers liens utiles de RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.1.1/useful-links', label: 'Liens utiles', description: 'Les divers liens utiles de RaidProtect.' }} />
 <br />

--- a/versioned_docs/version-3.2.0/readme.mdx
+++ b/versioned_docs/version-3.2.0/readme.mdx
@@ -29,22 +29,22 @@ Afin d'assurer le bon fonctionnement de RaidProtect :
 
 Une fois RaidProtect ajouté à votre serveur, exécutez la commande [`/setup`](./setup.md#install).
 
-<DocCard item={{ type: 'link', href: '/3.2.0/setup', docId: 'setup', label: 'Installation guidée' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.2.0/setup', docId: 'setup', label: 'Installation guidée' }} />
 <br />
 
 :::note
-Pour les moins téméraires (ou les plus pressés), vous pouvez simplement lire les indications de la [commande `/setup`](./setup.md#advanced) qui récapitule les principales informations de chaque fonctionnalités.
+Pour les moins téméraires (ou les plus pressés), vous pouvez simplement lire les indications de la [commande `/setup`](./setup.md#recommended) qui récapitule les principales informations de chaque fonctionnalités.
 :::
 
 ### Utilisation {#use}
 
 Consultez les différentes sections de cette documentation pour découvrir toutes les fonctionnalités offertes par RaidProtect.
 
-<DocCard item={{ type: 'link', href: '/3.2.0/language', docId: 'language', label: 'Langues disponibles' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.2.0/language', docId: 'language', label: 'Langues disponibles' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.2.0/features', label: 'Les fonctionnalités', description: 'Les documentations de chacune de nos fonctionnalités.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.2.0/features', label: 'Les fonctionnalités', description: 'Les documentations de chacune de nos fonctionnalités.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.2.0/guides', label: 'Nos guides', description: 'Des guides pour vous aider au mieux.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.2.0/guides', label: 'Nos guides', description: 'Des guides pour vous aider au mieux.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.2.0/useful-links', label: 'Liens utiles', description: 'Les divers liens utiles de RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.2.0/useful-links', label: 'Liens utiles', description: 'Les divers liens utiles de RaidProtect.' }} />
 <br />

--- a/versioned_docs/version-3.2.1/readme.mdx
+++ b/versioned_docs/version-3.2.1/readme.mdx
@@ -29,11 +29,11 @@ Afin d'assurer le bon fonctionnement de RaidProtect :
 
 Une fois RaidProtect ajouté à votre serveur, exécutez la commande [`/setup`](./setup.md#install).
 
-<DocCard item={{ type: 'link', href: '/setup', docId: 'setup', label: 'Installation guidée' }} />
+<DocCard item={{ type: 'link', href: '/docs/setup', docId: 'setup', label: 'Installation guidée' }} />
 <br />
 
 :::note
-Pour les moins téméraires (ou les plus pressés), vous pouvez simplement lire les indications de la [commande `/setup`](./setup.md#advanced) qui récapitule les principales informations de chaque fonctionnalités.
+Pour les moins téméraires (ou les plus pressés), vous pouvez simplement lire les indications de la [commande `/setup`](./setup.md#recommended) qui récapitule les principales informations de chaque fonctionnalités.
 :::
 
 ### Utilisation {#use}
@@ -44,11 +44,11 @@ Consultez les différentes sections de cette documentation pour découvrir toute
 Dans la documentation, les paramètres de commande sont affichés de cette manière lorsqu'elles sont `(obligatoires)` et lorsqu'elles sont `[facultatives]`.
 :::
 
-<DocCard item={{ type: 'link', href: '/language', docId: 'language', label: 'Langues disponibles' }} />
+<DocCard item={{ type: 'link', href: '/docs/language', docId: 'language', label: 'Langues disponibles' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/features', label: 'Les fonctionnalités', description: 'Les documentations de chacune de nos fonctionnalités.' }} />
+<DocCard item={{ type: 'category', href: '/docs/features', label: 'Les fonctionnalités', description: 'Les documentations de chacune de nos fonctionnalités.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/guides', label: 'Nos guides', description: 'Des guides pour vous aider au mieux.' }} />
+<DocCard item={{ type: 'category', href: '/docs/guides', label: 'Nos guides', description: 'Des guides pour vous aider au mieux.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/useful-links', label: 'Liens utiles', description: 'Les divers liens utiles de RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/useful-links', label: 'Liens utiles', description: 'Les divers liens utiles de RaidProtect.' }} />
 <br />

--- a/versioned_docs/version-3.3.0/readme.mdx
+++ b/versioned_docs/version-3.3.0/readme.mdx
@@ -29,11 +29,11 @@ Afin d'assurer le bon fonctionnement de RaidProtect :
 
 Une fois RaidProtect ajouté à votre serveur, exécutez la commande [`/setup`](./setup.md#install).
 
-<DocCard item={{ type: 'link', href: '/3.3.0/setup', docId: 'setup', label: 'Installation guidée' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.3.0/setup', docId: 'setup', label: 'Installation guidée' }} />
 <br />
 
 :::note
-Pour les moins téméraires (ou les plus pressés), vous pouvez simplement lire les indications de la [commande `/setup`](./setup.md#advanced) qui récapitule les principales informations de chaque fonctionnalités.
+Pour les moins téméraires (ou les plus pressés), vous pouvez simplement lire les indications de la [commande `/setup`](./setup.md#recommended) qui récapitule les principales informations de chaque fonctionnalités.
 :::
 
 ### Utilisation {#use}
@@ -44,11 +44,11 @@ Consultez les différentes sections de cette documentation pour découvrir toute
 Dans la documentation, les paramètres de commande sont affichés de cette manière lorsqu'elles sont `(obligatoires)` et lorsqu'elles sont `[facultatives]`.
 :::
 
-<DocCard item={{ type: 'link', href: '/3.3.0/language', docId: 'language', label: 'Langues disponibles' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.3.0/language', docId: 'language', label: 'Langues disponibles' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.0/features', label: 'Les fonctionnalités', description: 'Les documentations de chacune de nos fonctionnalités.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.0/features', label: 'Les fonctionnalités', description: 'Les documentations de chacune de nos fonctionnalités.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.0/guides', label: 'Nos guides', description: 'Des guides pour vous aider au mieux.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.0/guides', label: 'Nos guides', description: 'Des guides pour vous aider au mieux.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.0/useful-links', label: 'Liens utiles', description: 'Les divers liens utiles de RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.0/useful-links', label: 'Liens utiles', description: 'Les divers liens utiles de RaidProtect.' }} />
 <br />

--- a/versioned_docs/version-3.3.1/readme.mdx
+++ b/versioned_docs/version-3.3.1/readme.mdx
@@ -29,11 +29,11 @@ Afin d'assurer le bon fonctionnement de RaidProtect :
 
 Une fois RaidProtect ajouté à votre serveur, exécutez la commande [`/setup`](./setup.md#install).
 
-<DocCard item={{ type: 'link', href: '/setup', docId: 'setup', label: 'Installation guidée' }} />
+<DocCard item={{ type: 'link', href: '/docs/setup', docId: 'setup', label: 'Installation guidée' }} />
 <br />
 
 :::note
-Pour les moins téméraires (ou les plus pressés), vous pouvez simplement lire les indications de la [commande `/setup`](./setup.md#advanced) qui récapitule les principales informations de chaque fonctionnalités.
+Pour les moins téméraires (ou les plus pressés), vous pouvez simplement lire les indications de la [commande `/setup`](./setup.md#recommended) qui récapitule les principales informations de chaque fonctionnalités.
 :::
 
 ### Utilisation {#use}
@@ -44,11 +44,11 @@ Consultez les différentes sections de cette documentation pour découvrir toute
 Dans la documentation, les paramètres de commande sont affichés de cette manière lorsqu'elles sont `(obligatoires)` et lorsqu'elles sont `[facultatives]`.
 :::
 
-<DocCard item={{ type: 'link', href: '/language', docId: 'language', label: 'Langues disponibles' }} />
+<DocCard item={{ type: 'link', href: '/docs/language', docId: 'language', label: 'Langues disponibles' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/features', label: 'Les fonctionnalités', description: 'Les documentations de chacune de nos fonctionnalités.' }} />
+<DocCard item={{ type: 'category', href: '/docs/features', label: 'Les fonctionnalités', description: 'Les documentations de chacune de nos fonctionnalités.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/guides', label: 'Nos guides', description: 'Des guides pour vous aider au mieux.' }} />
+<DocCard item={{ type: 'category', href: '/docs/guides', label: 'Nos guides', description: 'Des guides pour vous aider au mieux.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/useful-links', label: 'Liens utiles', description: 'Les divers liens utiles de RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/useful-links', label: 'Liens utiles', description: 'Les divers liens utiles de RaidProtect.' }} />
 <br />

--- a/versioned_docs/version-3.3.2/readme.mdx
+++ b/versioned_docs/version-3.3.2/readme.mdx
@@ -29,11 +29,11 @@ Afin d'assurer le bon fonctionnement de RaidProtect :
 
 Une fois RaidProtect ajouté à votre serveur, exécutez la commande [`/setup`](./setup.md#install).
 
-<DocCard item={{ type: 'link', href: '/3.3.2/setup', docId: 'setup', label: 'Installation guidée' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.3.2/setup', docId: 'setup', label: 'Installation guidée' }} />
 <br />
 
 :::note
-Pour les moins téméraires (ou les plus pressés), vous pouvez simplement lire les indications de la [commande `/setup`](./setup.md#advanced) qui récapitule les principales informations de chaque fonctionnalités.
+Pour les moins téméraires (ou les plus pressés), vous pouvez simplement lire les indications de la [commande `/setup`](./setup.md#recommended) qui récapitule les principales informations de chaque fonctionnalités.
 :::
 
 ### Utilisation {#use}
@@ -44,11 +44,11 @@ Consultez les différentes sections de cette documentation pour découvrir toute
 Dans la documentation, les paramètres de commande sont affichés de cette manière lorsqu'elles sont `(obligatoires)` et lorsqu'elles sont `[facultatives]`.
 :::
 
-<DocCard item={{ type: 'link', href: '/3.3.2/language', docId: 'language', label: 'Langues disponibles' }} />
+<DocCard item={{ type: 'link', href: '/docs/3.3.2/language', docId: 'language', label: 'Langues disponibles' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.2/features', label: 'Les fonctionnalités', description: 'Les documentations de chacune de nos fonctionnalités.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.2/features', label: 'Les fonctionnalités', description: 'Les documentations de chacune de nos fonctionnalités.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.2/guides', label: 'Nos guides', description: 'Des guides pour vous aider au mieux.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.2/guides', label: 'Nos guides', description: 'Des guides pour vous aider au mieux.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/3.3.2/useful-links', label: 'Liens utiles', description: 'Les divers liens utiles de RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/3.3.2/useful-links', label: 'Liens utiles', description: 'Les divers liens utiles de RaidProtect.' }} />
 <br />

--- a/versioned_docs/version-3.3.3/readme.mdx
+++ b/versioned_docs/version-3.3.3/readme.mdx
@@ -29,11 +29,11 @@ Afin d'assurer le bon fonctionnement de RaidProtect :
 
 Une fois RaidProtect ajouté à votre serveur, exécutez la commande [`/setup`](./setup.md#install).
 
-<DocCard item={{ type: 'link', href: '/setup', docId: 'setup', label: 'Installation guidée' }} />
+<DocCard item={{ type: 'link', href: '/docs/setup', docId: 'setup', label: 'Installation guidée' }} />
 <br />
 
 :::note
-Pour les moins téméraires (ou les plus pressés), vous pouvez simplement lire les indications de la [commande `/setup`](./setup.md#advanced) qui récapitule les principales informations de chaque fonctionnalités.
+Pour les moins téméraires (ou les plus pressés), vous pouvez simplement lire les indications de la [commande `/setup`](./setup.md#recommended) qui récapitule les principales informations de chaque fonctionnalités.
 :::
 
 ### Utilisation {#use}
@@ -44,11 +44,11 @@ Consultez les différentes sections de cette documentation pour découvrir toute
 Dans la documentation, les paramètres de commande sont affichés de cette manière lorsqu'elles sont `(obligatoires)` et lorsqu'elles sont `[facultatives]`.
 :::
 
-<DocCard item={{ type: 'link', href: '/language', docId: 'language', label: 'Langues disponibles' }} />
+<DocCard item={{ type: 'link', href: '/docs/language', docId: 'language', label: 'Langues disponibles' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/features', label: 'Les fonctionnalités', description: 'Les documentations de chacune de nos fonctionnalités.' }} />
+<DocCard item={{ type: 'category', href: '/docs/features', label: 'Les fonctionnalités', description: 'Les documentations de chacune de nos fonctionnalités.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/guides', label: 'Nos guides', description: 'Des guides pour vous aider au mieux.' }} />
+<DocCard item={{ type: 'category', href: '/docs/guides', label: 'Nos guides', description: 'Des guides pour vous aider au mieux.' }} />
 <br />
-<DocCard item={{ type: 'category', href: '/useful-links', label: 'Liens utiles', description: 'Les divers liens utiles de RaidProtect.' }} />
+<DocCard item={{ type: 'category', href: '/docs/useful-links', label: 'Liens utiles', description: 'Les divers liens utiles de RaidProtect.' }} />
 <br />


### PR DESCRIPTION
Sous-PR de #25. Élimine tous les warnings 'broken links' / 'broken anchors' du build :

- DocCard hrefs des readme.mdx (3 versions × 5 locales) re-préfixés `/docs/`
- 2 liens absolus dans des blog posts FR/EN/DE/ES/PT qui avaient échappé au préfixage initial : `/features/reports`, `/features/display`
- Anchor `#advanced` du tip readme redirigé vers `#recommended` (la section Configuration avancée de setup.md est commentée donc l'ancre n'existe pas dans le rendu)

Build OK sur les 5 locales, plus aucun warning.