### PR TITLE
feat(premium): traduire la page premium (en/de/es/pt)

### DIFF
--- a/i18n/de/code.json
+++ b/i18n/de/code.json
@@ -405,7 +405,8 @@
     "message": "Wird geladen..."
   },
   "editor.authenticating": {
-    "message": "Authentifizierung läuft..."
+    "message": "Authentifizierung läuft...",
+    "description": "Authenticating message"
   },
   "editor.exitBar.backToDocs": {
     "message": "Zurück zur Dokumentation"
@@ -446,7 +447,7 @@
   },
   "servers.memberCount": {
     "message": "{count} Mitglieder",
-    "description": "Server card: number of members; {count} is locale-formatted"
+    "description": "Server card: number of members (e.g. '40 000 members'); {count} is locale-formatted"
   },
   "frame.cta.title": {
     "message": "Einen Schritt {highlight} bleiben",
@@ -847,5 +848,300 @@
   "permission.moveMembers": {
     "message": "Mitglieder verschieben",
     "description": "Discord permission name"
+  },
+  "premium.feature.customize.title": {
+    "message": "Vollständige Bot-Anpassung"
+  },
+  "premium.feature.customize.desc": {
+    "message": "Avatar, Banner, Name und Schreibstil: RaidProtect nimmt die Identität Ihres Servers an."
+  },
+  "premium.feature.authManager.title": {
+    "message": "Erweiterter Authentication Manager"
+  },
+  "premium.feature.authManager.desc": {
+    "message": "Mehr geschützte Rollen, mehr autorisierte Nutzer und doppelt so lange Sitzungen."
+  },
+  "premium.feature.sanctionNames.title": {
+    "message": "Anpassbare Sanktionsnamen"
+  },
+  "premium.feature.sanctionNames.desc": {
+    "message": "Passen Sie jede Sanktion an das Vokabular Ihrer Community an."
+  },
+  "premium.feature.display.title": {
+    "message": "Mehr Infotafeln"
+  },
+  "premium.feature.display.desc": {
+    "message": "Doppelt so viele freie Tafeln mit /display public (2 → 4), Jail-Slot immer inklusive."
+  },
+  "premium.feature.honeypot.title": {
+    "message": "Erweiterte Honeypot-Sanktionen"
+  },
+  "premium.feature.honeypot.desc": {
+    "message": "Schalten Sie Kick, Timeout, Jail und Mute im HoneyPot-Modul frei."
+  },
+  "premium.experiment.badge.publicBeta": {
+    "message": "Öffentliche Beta"
+  },
+  "premium.experiment.automod.title": {
+    "message": "AutoMod-Umwandlung in rollenbasierten Mute"
+  },
+  "premium.experiment.automod.desc": {
+    "message": "Von Discords AutoMod verhängte Timeouts werden ab dem konfigurierten Schwellenwert automatisch in rollenbasierte Mutes umgewandelt, für volle Konsistenz mit Ihren manuellen Sanktionen."
+  },
+  "premium.experiment.badge.soon": {
+    "message": "Demnächst"
+  },
+  "premium.experiment.more.title": {
+    "message": "Weitere Experimente folgen bald"
+  },
+  "premium.experiment.more.desc": {
+    "message": "Premium-Abonnenten erhalten vorab Zugang zu Funktionen der öffentlichen Beta. Wir halten die aktuelle Liste hier fest, sobald sie verfügbar sind."
+  },
+  "premium.tier.free.name": {
+    "message": "Basic"
+  },
+  "premium.tier.free.tagline": {
+    "message": "Grundlegende Sicherheit, für immer kostenlos."
+  },
+  "premium.tier.free.price": {
+    "message": "Kostenlos"
+  },
+  "premium.tier.free.cta": {
+    "message": "Zu Discord hinzufügen"
+  },
+  "premium.tier.founder.name": {
+    "message": "Founder"
+  },
+  "premium.tier.founder.tagline": {
+    "message": "Einführungsangebot, reserviert für die ersten Abonnenten."
+  },
+  "premium.tier.founder.priceUnit": {
+    "message": "/ Monat"
+  },
+  "premium.tier.founder.cta": {
+    "message": "Über Discord abonnieren"
+  },
+  "premium.tier.business.name": {
+    "message": "Business"
+  },
+  "premium.tier.business.tagline": {
+    "message": "Für Projekte mit hohen Sicherheitsanforderungen."
+  },
+  "premium.tier.business.price": {
+    "message": "Auf Anfrage"
+  },
+  "premium.tier.business.cta": {
+    "message": "Termin vereinbaren"
+  },
+  "premium.compare.included": {
+    "message": "Enthalten"
+  },
+  "premium.compare.notIncluded": {
+    "message": "Nicht enthalten"
+  },
+  "premium.compare.custom": {
+    "message": "Individuell"
+  },
+  "premium.compare.cat.essential": {
+    "message": "Grundschutz"
+  },
+  "premium.compare.row.antispam": {
+    "message": "Adaptiver Anti-Spam"
+  },
+  "premium.compare.row.captcha": {
+    "message": "Captcha & Verifizierung"
+  },
+  "premium.compare.row.antiraid": {
+    "message": "Automatischer Anti-Raid"
+  },
+  "premium.compare.row.antiscam": {
+    "message": "Anti-Scam & ScamLens"
+  },
+  "premium.compare.row.moderation": {
+    "message": "Vollständige Moderation (Bann, Kick, Mute, Jail …)"
+  },
+  "premium.compare.cat.authManager": {
+    "message": "Authentication Manager"
+  },
+  "premium.compare.row.protectedRoles": {
+    "message": "Geschützte Rollen"
+  },
+  "premium.compare.row.authorizedUsers": {
+    "message": "Autorisierte Nutzer"
+  },
+  "premium.compare.row.sessionDuration": {
+    "message": "Sitzungsdauer"
+  },
+  "premium.compare.cat.display": {
+    "message": "Öffentliche Anzeige"
+  },
+  "premium.compare.row.panels": {
+    "message": "Infotafeln"
+  },
+  "premium.compare.row.panels.free": {
+    "message": "2 + 1 Jail"
+  },
+  "premium.compare.row.panels.founder": {
+    "message": "4 + 1 Jail"
+  },
+  "premium.compare.cat.honeypot": {
+    "message": "HoneyPot"
+  },
+  "premium.compare.row.banSoftban": {
+    "message": "Bann & Softban"
+  },
+  "premium.compare.row.kickTimeout": {
+    "message": "Kick, Timeout, Jail, Mute"
+  },
+  "premium.compare.cat.customization": {
+    "message": "Anpassung"
+  },
+  "premium.compare.row.botIdentity": {
+    "message": "Name, Avatar und Banner des Bots"
+  },
+  "premium.compare.row.nameStyle": {
+    "message": "Namensstil (8 Schriftarten, 4 Effekte)"
+  },
+  "premium.compare.row.customSanctions": {
+    "message": "Individuelle Sanktionsnamen"
+  },
+  "premium.compare.row.bio": {
+    "message": "Anpassbare Bio"
+  },
+  "premium.compare.row.dedicatedInstance": {
+    "message": "Dedizierte, isolierte Instanz"
+  },
+  "premium.compare.cat.support": {
+    "message": "Betreuung"
+  },
+  "premium.compare.row.communitySupport": {
+    "message": "Community-Support"
+  },
+  "premium.compare.row.betaAccess": {
+    "message": "Zugang zu Funktionen der öffentlichen Beta"
+  },
+  "premium.compare.row.exclusiveRole": {
+    "message": "Exklusive Rolle auf dem RaidProtect-Server"
+  },
+  "premium.compare.row.prioritySupport": {
+    "message": "Priorisierter Support"
+  },
+  "premium.compare.row.audit": {
+    "message": "Erstes Server-Audit"
+  },
+  "premium.compare.row.customIntegration": {
+    "message": "Maßgeschneiderte Integration"
+  },
+  "premium.compare.row.expertFollowup": {
+    "message": "Regelmäßige Betreuung durch einen Experten"
+  },
+  "premium.layout.title": {
+    "message": "Premium"
+  },
+  "premium.layout.description": {
+    "message": "Entdecken Sie RaidProtect Premium: Bot-Anpassung, erweiterter Authentication Manager, fortgeschrittene HoneyPot-Sanktionen, Zugang zu Funktionen der öffentlichen Beta."
+  },
+  "premium.hero.title.line1": {
+    "message": "Schutz in Ihrem Stil,",
+    "description": "Première ligne du titre du hero premium"
+  },
+  "premium.hero.title.accent": {
+    "message": "ohne Kompromisse",
+    "description": "Partie accentuée du titre du hero premium"
+  },
+  "premium.hero.subtitle": {
+    "message": "Schalten Sie die erweiterten Funktionen von RaidProtect frei: vollständige Anpassung, erweiterte Limits bei den wichtigsten Modulen, maßgeschneiderte Sanktionen und frühzeitigen Zugang zu Neuheiten."
+  },
+  "premium.hero.cta.subscribe": {
+    "message": "Für 2,99 $/Monat abonnieren"
+  },
+  "premium.hero.cta.compare": {
+    "message": "Tarife vergleichen"
+  },
+  "premium.stats.servers": {
+    "message": "Geschützte Server"
+  },
+  "premium.stats.users": {
+    "message": "Überwachte Nutzer"
+  },
+  "premium.stats.captcha": {
+    "message": "Gelöste Captchas"
+  },
+  "premium.stats.antispam": {
+    "message": "Gefilterte Anti-Spam-Nachrichten"
+  },
+  "premium.servers.title": {
+    "message": "Sie vertrauen uns"
+  },
+  "premium.features.eyebrow": {
+    "message": "Was Sie freischalten"
+  },
+  "premium.features.title": {
+    "message": "Die wichtigsten Premium-Vorteile"
+  },
+  "premium.features.subtitle": {
+    "message": "Fünf konkrete Hebel, um mit RaidProtect weiterzukommen, ohne Ihre Arbeitsweise zu ändern."
+  },
+  "premium.cta.subscribe": {
+    "message": "Abonnieren"
+  },
+  "premium.experiments.eyebrow": {
+    "message": "Innovationsprogramm"
+  },
+  "premium.experiments.title": {
+    "message": "Funktionen der öffentlichen Beta"
+  },
+  "premium.experiments.subtitle": {
+    "message": "Abonnenten erhalten vorab Zugang zu Funktionen, die noch stabilisiert werden. Diese Vorteile entwickeln sich mit jedem Bot-Update weiter."
+  },
+  "premium.experiment.learnMore": {
+    "message": "Mehr erfahren →"
+  },
+  "premium.compare.eyebrow": {
+    "message": "Tarifvergleich"
+  },
+  "premium.compare.title": {
+    "message": "Wählen Sie den Tarif, der zu Ihnen passt"
+  },
+  "premium.compare.subtitle": {
+    "message": "Alle grundlegenden Schutzfunktionen bleiben kostenlos. Premium schaltet Anpassung und erweiterte Limits frei. Business bietet eine dedizierte Instanz und persönliche Betreuung."
+  },
+  "premium.finalCta.title": {
+    "message": "Bereit für Premium?"
+  },
+  "premium.finalCta.subtitle": {
+    "message": "Das Founder-Angebot ist zeitlich begrenzt: 2,99 $/Monat auf Lebenszeit für die ersten Abonnenten."
+  },
+  "premium.finalCta.cta": {
+    "message": "Premium jetzt aktivieren"
+  },
+  "commands.copy.label": {
+    "message": "Copier la commande",
+    "description": "Aria-label of the copy button on command cells"
+  },
+  "theme.docs.sidebar.versionLabel": {
+    "message": "Version",
+    "description": "Label of the version selector in the docs sidebar"
+  },
+  "editor.sidebar.title": {
+    "message": "Files"
+  },
+  "editor.contribute.title": {
+    "message": "Contribute to the documentation"
+  },
+  "editor.contribute.description": {
+    "message": "Help improve the documentation by editing existing pages. Choose a page below or search for one."
+  },
+  "editor.contribute.searchPlaceholder": {
+    "message": "Search for a page..."
+  },
+  "editor.contribute.noResults": {
+    "message": "No pages found."
+  },
+  "editor.contribute.featured": {
+    "message": "Suggested pages"
+  },
+  "premium.tier.founder.price": {
+    "message": "2,99 $"
   }
 }

--- a/i18n/de/docusaurus-theme-classic/footer.json
+++ b/i18n/de/docusaurus-theme-classic/footer.json
@@ -21,7 +21,7 @@
   },
   "link.item.label.Documentation": {
     "message": "Dokumentation",
-    "description": "The label of footer link with label=Documentation linking to /"
+    "description": "The label of footer link with label=Documentation linking to /docs"
   },
   "link.item.label.Suggestions": {
     "message": "Vorschläge",
@@ -29,7 +29,7 @@
   },
   "link.item.label.Mentions légales": {
     "message": "Impressum",
-    "description": "The label of footer link with label=Mentions légales linking to legal"
+    "description": "The label of footer link with label=Mentions légales linking to /legal"
   },
   "link.item.label.Statuts des services": {
     "message": "Status der Dienste",
@@ -41,14 +41,14 @@
   },
   "link.item.label.Conditions d'utilisation": {
     "message": "Nutzungsbedingungen",
-    "description": "The label of footer link with label=Conditions d'utilisation linking to terms"
+    "description": "The label of footer link with label=Conditions d'utilisation linking to /terms"
   },
   "link.item.label.Politique de confidentialité": {
     "message": "Datenschutzerklärung",
-    "description": "The label of footer link with label=Politique de confidentialité linking to privacy"
+    "description": "The label of footer link with label=Politique de confidentialité linking to /privacy"
   },
   "link.item.label.Politique des cookies": {
     "message": "Cookie-Richtlinie",
-    "description": "The label of footer link with label=Politique des cookies linking to cookies"
+    "description": "The label of footer link with label=Politique des cookies linking to /cookies"
   }
 }

--- a/i18n/de/docusaurus-theme-classic/navbar.json
+++ b/i18n/de/docusaurus-theme-classic/navbar.json
@@ -18,5 +18,9 @@
   "item.label.Blog": {
     "message": "Blog",
     "description": "Navbar item with label Blog"
+  },
+  "item.label.Premium": {
+    "message": "Premium",
+    "description": "Navbar item with label Premium"
   }
 }

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -405,7 +405,8 @@
     "message": "Loading..."
   },
   "editor.authenticating": {
-    "message": "Authenticating..."
+    "message": "Authenticating...",
+    "description": "Authenticating message"
   },
   "editor.exitBar.backToDocs": {
     "message": "Back to documentation"
@@ -446,7 +447,7 @@
   },
   "servers.memberCount": {
     "message": "{count} members",
-    "description": "Server card: number of members (e.g. '40,000 members'); {count} is locale-formatted"
+    "description": "Server card: number of members (e.g. '40 000 members'); {count} is locale-formatted"
   },
   "frame.cta.title": {
     "message": "Keeping one step {highlight}",
@@ -847,5 +848,300 @@
   "permission.moveMembers": {
     "message": "Move Members",
     "description": "Discord permission name"
+  },
+  "premium.feature.customize.title": {
+    "message": "Full bot customization"
+  },
+  "premium.feature.customize.desc": {
+    "message": "Avatar, banner, nickname and writing style: RaidProtect takes on your server's identity."
+  },
+  "premium.feature.authManager.title": {
+    "message": "Extended Authentication Manager"
+  },
+  "premium.feature.authManager.desc": {
+    "message": "More protected roles, more authorized users and sessions twice as long."
+  },
+  "premium.feature.sanctionNames.title": {
+    "message": "Customizable sanction names"
+  },
+  "premium.feature.sanctionNames.desc": {
+    "message": "Adapt each sanction to your community's vocabulary."
+  },
+  "premium.feature.display.title": {
+    "message": "More information panels"
+  },
+  "premium.feature.display.desc": {
+    "message": "Twice as many free panels with /display public (2 → 4), Jail slot always included."
+  },
+  "premium.feature.honeypot.title": {
+    "message": "Advanced Honeypot sanctions"
+  },
+  "premium.feature.honeypot.desc": {
+    "message": "Unlock Kick, Timeout, Jail and Mute in the HoneyPot module."
+  },
+  "premium.experiment.badge.publicBeta": {
+    "message": "Public beta"
+  },
+  "premium.experiment.automod.title": {
+    "message": "AutoMod to role-based mute conversion"
+  },
+  "premium.experiment.automod.desc": {
+    "message": "Timeouts applied by Discord's AutoMod are automatically converted into role-based mutes beyond the configured threshold, for full consistency with your manual sanctions."
+  },
+  "premium.experiment.badge.soon": {
+    "message": "Soon"
+  },
+  "premium.experiment.more.title": {
+    "message": "More experiments coming soon"
+  },
+  "premium.experiment.more.desc": {
+    "message": "Premium subscribers get early access to public beta features. We keep the up-to-date list here as they arrive."
+  },
+  "premium.tier.free.name": {
+    "message": "Basic"
+  },
+  "premium.tier.free.tagline": {
+    "message": "Essential security, free forever."
+  },
+  "premium.tier.free.price": {
+    "message": "Free"
+  },
+  "premium.tier.free.cta": {
+    "message": "Add to Discord"
+  },
+  "premium.tier.founder.name": {
+    "message": "Founder"
+  },
+  "premium.tier.founder.tagline": {
+    "message": "Launch offer reserved for the first subscribers."
+  },
+  "premium.tier.founder.priceUnit": {
+    "message": "/ month"
+  },
+  "premium.tier.founder.cta": {
+    "message": "Subscribe via Discord"
+  },
+  "premium.tier.business.name": {
+    "message": "Business"
+  },
+  "premium.tier.business.tagline": {
+    "message": "For projects with high security requirements."
+  },
+  "premium.tier.business.price": {
+    "message": "On request"
+  },
+  "premium.tier.business.cta": {
+    "message": "Book a meeting"
+  },
+  "premium.compare.included": {
+    "message": "Included"
+  },
+  "premium.compare.notIncluded": {
+    "message": "Not included"
+  },
+  "premium.compare.custom": {
+    "message": "Custom"
+  },
+  "premium.compare.cat.essential": {
+    "message": "Essential protection"
+  },
+  "premium.compare.row.antispam": {
+    "message": "Adaptive anti-spam"
+  },
+  "premium.compare.row.captcha": {
+    "message": "Captcha & verification"
+  },
+  "premium.compare.row.antiraid": {
+    "message": "Automatic anti-raid"
+  },
+  "premium.compare.row.antiscam": {
+    "message": "Anti-Scam & ScamLens"
+  },
+  "premium.compare.row.moderation": {
+    "message": "Full moderation (ban, kick, mute, jail…)"
+  },
+  "premium.compare.cat.authManager": {
+    "message": "Authentication Manager"
+  },
+  "premium.compare.row.protectedRoles": {
+    "message": "Protected roles"
+  },
+  "premium.compare.row.authorizedUsers": {
+    "message": "Authorized users"
+  },
+  "premium.compare.row.sessionDuration": {
+    "message": "Session duration"
+  },
+  "premium.compare.cat.display": {
+    "message": "Public display"
+  },
+  "premium.compare.row.panels": {
+    "message": "Information panels"
+  },
+  "premium.compare.row.panels.free": {
+    "message": "2 + 1 Jail"
+  },
+  "premium.compare.row.panels.founder": {
+    "message": "4 + 1 Jail"
+  },
+  "premium.compare.cat.honeypot": {
+    "message": "HoneyPot"
+  },
+  "premium.compare.row.banSoftban": {
+    "message": "Ban & softban"
+  },
+  "premium.compare.row.kickTimeout": {
+    "message": "Kick, Timeout, Jail, Mute"
+  },
+  "premium.compare.cat.customization": {
+    "message": "Customization"
+  },
+  "premium.compare.row.botIdentity": {
+    "message": "Bot nickname, avatar and banner"
+  },
+  "premium.compare.row.nameStyle": {
+    "message": "Name styling (8 fonts, 4 effects)"
+  },
+  "premium.compare.row.customSanctions": {
+    "message": "Custom sanction names"
+  },
+  "premium.compare.row.bio": {
+    "message": "Customizable bio"
+  },
+  "premium.compare.row.dedicatedInstance": {
+    "message": "Dedicated, isolated instance"
+  },
+  "premium.compare.cat.support": {
+    "message": "Support & guidance"
+  },
+  "premium.compare.row.communitySupport": {
+    "message": "Community support"
+  },
+  "premium.compare.row.betaAccess": {
+    "message": "Access to public beta features"
+  },
+  "premium.compare.row.exclusiveRole": {
+    "message": "Exclusive role on the RaidProtect server"
+  },
+  "premium.compare.row.prioritySupport": {
+    "message": "Priority support"
+  },
+  "premium.compare.row.audit": {
+    "message": "Initial server audit"
+  },
+  "premium.compare.row.customIntegration": {
+    "message": "Custom integration"
+  },
+  "premium.compare.row.expertFollowup": {
+    "message": "Regular follow-up with an expert"
+  },
+  "premium.layout.title": {
+    "message": "Premium"
+  },
+  "premium.layout.description": {
+    "message": "Discover RaidProtect Premium: bot customization, extended Authentication Manager, advanced HoneyPot sanctions, access to public beta features."
+  },
+  "premium.hero.title.line1": {
+    "message": "Protection in your image,",
+    "description": "Première ligne du titre du hero premium"
+  },
+  "premium.hero.title.accent": {
+    "message": "without compromise",
+    "description": "Partie accentuée du titre du hero premium"
+  },
+  "premium.hero.subtitle": {
+    "message": "Unlock RaidProtect's advanced features: full customization, extended limits on key modules, tailor-made sanctions and early access to new features."
+  },
+  "premium.hero.cta.subscribe": {
+    "message": "Subscribe for $2.99/month"
+  },
+  "premium.hero.cta.compare": {
+    "message": "Compare plans"
+  },
+  "premium.stats.servers": {
+    "message": "Protected servers"
+  },
+  "premium.stats.users": {
+    "message": "Monitored users"
+  },
+  "premium.stats.captcha": {
+    "message": "Captchas solved"
+  },
+  "premium.stats.antispam": {
+    "message": "Anti-spam messages filtered"
+  },
+  "premium.servers.title": {
+    "message": "They trust us"
+  },
+  "premium.features.eyebrow": {
+    "message": "What you unlock"
+  },
+  "premium.features.title": {
+    "message": "The key Premium benefits"
+  },
+  "premium.features.subtitle": {
+    "message": "Five concrete levers to go further with RaidProtect, without changing the way you work."
+  },
+  "premium.cta.subscribe": {
+    "message": "Subscribe"
+  },
+  "premium.experiments.eyebrow": {
+    "message": "Innovation program"
+  },
+  "premium.experiments.title": {
+    "message": "Public beta features"
+  },
+  "premium.experiments.subtitle": {
+    "message": "Subscribers get early access to features still being stabilized. These perks evolve with every bot update."
+  },
+  "premium.experiment.learnMore": {
+    "message": "Learn more →"
+  },
+  "premium.compare.eyebrow": {
+    "message": "Plan comparison"
+  },
+  "premium.compare.title": {
+    "message": "Choose the plan that fits you"
+  },
+  "premium.compare.subtitle": {
+    "message": "All essential protections stay free. Premium unlocks customization and extended limits. Business adds a dedicated instance and human guidance."
+  },
+  "premium.finalCta.title": {
+    "message": "Ready to go Premium?"
+  },
+  "premium.finalCta.subtitle": {
+    "message": "The Founder offer is time-limited: $2.99/month for life for the first subscribers."
+  },
+  "premium.finalCta.cta": {
+    "message": "Activate Premium now"
+  },
+  "commands.copy.label": {
+    "message": "Copier la commande",
+    "description": "Aria-label of the copy button on command cells"
+  },
+  "theme.docs.sidebar.versionLabel": {
+    "message": "Version",
+    "description": "Label of the version selector in the docs sidebar"
+  },
+  "editor.sidebar.title": {
+    "message": "Files"
+  },
+  "editor.contribute.title": {
+    "message": "Contribute to the documentation"
+  },
+  "editor.contribute.description": {
+    "message": "Help improve the documentation by editing existing pages. Choose a page below or search for one."
+  },
+  "editor.contribute.searchPlaceholder": {
+    "message": "Search for a page..."
+  },
+  "editor.contribute.noResults": {
+    "message": "No pages found."
+  },
+  "editor.contribute.featured": {
+    "message": "Suggested pages"
+  },
+  "premium.tier.founder.price": {
+    "message": "$2.99"
   }
 }

--- a/i18n/en/docusaurus-theme-classic/footer.json
+++ b/i18n/en/docusaurus-theme-classic/footer.json
@@ -21,7 +21,7 @@
   },
   "link.item.label.Documentation": {
     "message": "Documentation",
-    "description": "The label of footer link with label=Documentation linking to /"
+    "description": "The label of footer link with label=Documentation linking to /docs"
   },
   "link.item.label.Suggestions": {
     "message": "Suggestions",
@@ -29,7 +29,7 @@
   },
   "link.item.label.Mentions légales": {
     "message": "Legal notices",
-    "description": "The label of footer link with label=Mentions légales linking to legal"
+    "description": "The label of footer link with label=Mentions légales linking to /legal"
   },
   "link.item.label.Statuts des services": {
     "message": "Status of services",
@@ -41,14 +41,14 @@
   },
   "link.item.label.Conditions d'utilisation": {
     "message": "Terms of Service",
-    "description": "The label of footer link with label=Conditions d'utilisation linking to terms"
+    "description": "The label of footer link with label=Conditions d'utilisation linking to /terms"
   },
   "link.item.label.Politique de confidentialité": {
     "message": "Privacy Policy",
-    "description": "The label of footer link with label=Politique de confidentialité linking to privacy"
+    "description": "The label of footer link with label=Politique de confidentialité linking to /privacy"
   },
   "link.item.label.Politique des cookies": {
     "message": "Cookie Policy",
-    "description": "The label of footer link with label=Politique des cookies linking to cookies"
+    "description": "The label of footer link with label=Politique des cookies linking to /cookies"
   }
 }

--- a/i18n/en/docusaurus-theme-classic/navbar.json
+++ b/i18n/en/docusaurus-theme-classic/navbar.json
@@ -18,5 +18,9 @@
   "item.label.Blog": {
     "message": "Blog",
     "description": "Navbar item with label Blog"
+  },
+  "item.label.Premium": {
+    "message": "Premium",
+    "description": "Navbar item with label Premium"
   }
 }

--- a/i18n/es/code.json
+++ b/i18n/es/code.json
@@ -405,7 +405,8 @@
     "message": "Cargando..."
   },
   "editor.authenticating": {
-    "message": "Autenticando..."
+    "message": "Autenticando...",
+    "description": "Authenticating message"
   },
   "editor.exitBar.backToDocs": {
     "message": "Volver a la documentación"
@@ -446,7 +447,7 @@
   },
   "servers.memberCount": {
     "message": "{count} miembros",
-    "description": "Server card: number of members; {count} is locale-formatted"
+    "description": "Server card: number of members (e.g. '40 000 members'); {count} is locale-formatted"
   },
   "frame.cta.title": {
     "message": "Mantente a la {highlight}",
@@ -847,5 +848,300 @@
   "permission.moveMembers": {
     "message": "Mover miembros",
     "description": "Discord permission name"
+  },
+  "premium.feature.customize.title": {
+    "message": "Personalización total del bot"
+  },
+  "premium.feature.customize.desc": {
+    "message": "Avatar, banner, apodo y estilo de escritura: RaidProtect adopta la identidad de tu servidor."
+  },
+  "premium.feature.authManager.title": {
+    "message": "Authentication Manager ampliado"
+  },
+  "premium.feature.authManager.desc": {
+    "message": "Más roles protegidos, más usuarios autorizados y sesiones el doble de largas."
+  },
+  "premium.feature.sanctionNames.title": {
+    "message": "Nombres de sanciones personalizables"
+  },
+  "premium.feature.sanctionNames.desc": {
+    "message": "Adapta cada sanción al vocabulario de tu comunidad."
+  },
+  "premium.feature.display.title": {
+    "message": "Más paneles de información"
+  },
+  "premium.feature.display.desc": {
+    "message": "El doble de paneles libres con /display public (2 → 4), espacio Jail siempre incluido."
+  },
+  "premium.feature.honeypot.title": {
+    "message": "Sanciones Honeypot avanzadas"
+  },
+  "premium.feature.honeypot.desc": {
+    "message": "Desbloquea Kick, Timeout, Jail y Mute en el módulo HoneyPot."
+  },
+  "premium.experiment.badge.publicBeta": {
+    "message": "Beta pública"
+  },
+  "premium.experiment.automod.title": {
+    "message": "Conversión de AutoMod a mute por rol"
+  },
+  "premium.experiment.automod.desc": {
+    "message": "Los timeouts aplicados por el AutoMod de Discord se convierten automáticamente en mute por rol más allá del umbral configurado, para una coherencia total con tus sanciones manuales."
+  },
+  "premium.experiment.badge.soon": {
+    "message": "Pronto"
+  },
+  "premium.experiment.more.title": {
+    "message": "Más experimentos en camino"
+  },
+  "premium.experiment.more.desc": {
+    "message": "Los suscriptores Premium reciben en primicia las funciones en beta pública. Aquí publicamos la lista actualizada a medida que llegan."
+  },
+  "premium.tier.free.name": {
+    "message": "Basic"
+  },
+  "premium.tier.free.tagline": {
+    "message": "La seguridad esencial, gratis para siempre."
+  },
+  "premium.tier.free.price": {
+    "message": "Gratis"
+  },
+  "premium.tier.free.cta": {
+    "message": "Añadir a Discord"
+  },
+  "premium.tier.founder.name": {
+    "message": "Founder"
+  },
+  "premium.tier.founder.tagline": {
+    "message": "Oferta de lanzamiento reservada a los primeros suscriptores."
+  },
+  "premium.tier.founder.priceUnit": {
+    "message": "/ mes"
+  },
+  "premium.tier.founder.cta": {
+    "message": "Suscribirse vía Discord"
+  },
+  "premium.tier.business.name": {
+    "message": "Business"
+  },
+  "premium.tier.business.tagline": {
+    "message": "Para proyectos con altas exigencias de seguridad."
+  },
+  "premium.tier.business.price": {
+    "message": "Bajo petición"
+  },
+  "premium.tier.business.cta": {
+    "message": "Pedir una cita"
+  },
+  "premium.compare.included": {
+    "message": "Incluido"
+  },
+  "premium.compare.notIncluded": {
+    "message": "No incluido"
+  },
+  "premium.compare.custom": {
+    "message": "Personalizado"
+  },
+  "premium.compare.cat.essential": {
+    "message": "Protección esencial"
+  },
+  "premium.compare.row.antispam": {
+    "message": "Anti-spam adaptativo"
+  },
+  "premium.compare.row.captcha": {
+    "message": "Captcha y verificación"
+  },
+  "premium.compare.row.antiraid": {
+    "message": "Anti-raid automático"
+  },
+  "premium.compare.row.antiscam": {
+    "message": "Anti-Scam y ScamLens"
+  },
+  "premium.compare.row.moderation": {
+    "message": "Moderación completa (ban, kick, mute, jail…)"
+  },
+  "premium.compare.cat.authManager": {
+    "message": "Authentication Manager"
+  },
+  "premium.compare.row.protectedRoles": {
+    "message": "Roles protegidos"
+  },
+  "premium.compare.row.authorizedUsers": {
+    "message": "Usuarios autorizados"
+  },
+  "premium.compare.row.sessionDuration": {
+    "message": "Duración de la sesión"
+  },
+  "premium.compare.cat.display": {
+    "message": "Display público"
+  },
+  "premium.compare.row.panels": {
+    "message": "Paneles de información"
+  },
+  "premium.compare.row.panels.free": {
+    "message": "2 + 1 Jail"
+  },
+  "premium.compare.row.panels.founder": {
+    "message": "4 + 1 Jail"
+  },
+  "premium.compare.cat.honeypot": {
+    "message": "HoneyPot"
+  },
+  "premium.compare.row.banSoftban": {
+    "message": "Baneo y softban"
+  },
+  "premium.compare.row.kickTimeout": {
+    "message": "Kick, Timeout, Jail, Mute"
+  },
+  "premium.compare.cat.customization": {
+    "message": "Personalización"
+  },
+  "premium.compare.row.botIdentity": {
+    "message": "Apodo, avatar y banner del bot"
+  },
+  "premium.compare.row.nameStyle": {
+    "message": "Estilo del nombre (8 fuentes, 4 efectos)"
+  },
+  "premium.compare.row.customSanctions": {
+    "message": "Nombres de sanciones personalizados"
+  },
+  "premium.compare.row.bio": {
+    "message": "Biografía personalizable"
+  },
+  "premium.compare.row.dedicatedInstance": {
+    "message": "Instancia dedicada y aislada"
+  },
+  "premium.compare.cat.support": {
+    "message": "Acompañamiento"
+  },
+  "premium.compare.row.communitySupport": {
+    "message": "Soporte comunitario"
+  },
+  "premium.compare.row.betaAccess": {
+    "message": "Acceso a las funciones en beta pública"
+  },
+  "premium.compare.row.exclusiveRole": {
+    "message": "Rol exclusivo en el servidor de RaidProtect"
+  },
+  "premium.compare.row.prioritySupport": {
+    "message": "Soporte prioritario"
+  },
+  "premium.compare.row.audit": {
+    "message": "Auditoría inicial del servidor"
+  },
+  "premium.compare.row.customIntegration": {
+    "message": "Integración a medida"
+  },
+  "premium.compare.row.expertFollowup": {
+    "message": "Seguimiento regular con un experto"
+  },
+  "premium.layout.title": {
+    "message": "Premium"
+  },
+  "premium.layout.description": {
+    "message": "Descubre RaidProtect Premium: personalización del bot, Authentication Manager ampliado, sanciones HoneyPot avanzadas, acceso a las funciones en beta pública."
+  },
+  "premium.hero.title.line1": {
+    "message": "Una protección a tu imagen,",
+    "description": "Première ligne du titre du hero premium"
+  },
+  "premium.hero.title.accent": {
+    "message": "sin concesiones",
+    "description": "Partie accentuée du titre du hero premium"
+  },
+  "premium.hero.subtitle": {
+    "message": "Desbloquea las funciones avanzadas de RaidProtect: personalización total, límites ampliados en los módulos clave, sanciones a medida y acceso anticipado a las novedades."
+  },
+  "premium.hero.cta.subscribe": {
+    "message": "Suscribirse por 2,99 $/mes"
+  },
+  "premium.hero.cta.compare": {
+    "message": "Comparar planes"
+  },
+  "premium.stats.servers": {
+    "message": "Servidores protegidos"
+  },
+  "premium.stats.users": {
+    "message": "Usuarios supervisados"
+  },
+  "premium.stats.captcha": {
+    "message": "Captchas resueltos"
+  },
+  "premium.stats.antispam": {
+    "message": "Mensajes anti-spam filtrados"
+  },
+  "premium.servers.title": {
+    "message": "Confían en nosotros"
+  },
+  "premium.features.eyebrow": {
+    "message": "Lo que desbloqueas"
+  },
+  "premium.features.title": {
+    "message": "Las ventajas clave de Premium"
+  },
+  "premium.features.subtitle": {
+    "message": "Cinco palancas concretas para ir más lejos con RaidProtect, sin cambiar tu manera de trabajar."
+  },
+  "premium.cta.subscribe": {
+    "message": "Suscribirse"
+  },
+  "premium.experiments.eyebrow": {
+    "message": "Programa de innovación"
+  },
+  "premium.experiments.title": {
+    "message": "Funciones en beta pública"
+  },
+  "premium.experiments.subtitle": {
+    "message": "Los suscriptores reciben en primicia las novedades en proceso de estabilización. Estos accesos evolucionan con cada actualización del bot."
+  },
+  "premium.experiment.learnMore": {
+    "message": "Saber más →"
+  },
+  "premium.compare.eyebrow": {
+    "message": "Comparativa de planes"
+  },
+  "premium.compare.title": {
+    "message": "Elige el plan que mejor se adapte a ti"
+  },
+  "premium.compare.subtitle": {
+    "message": "Todas las protecciones esenciales siguen siendo gratuitas. Premium abre la personalización y los límites ampliados. Business aporta una instancia dedicada y un acompañamiento humano."
+  },
+  "premium.finalCta.title": {
+    "message": "¿Listo para pasar a Premium?"
+  },
+  "premium.finalCta.subtitle": {
+    "message": "La oferta Founder es limitada en el tiempo: 2,99 $/mes de por vida para los primeros suscriptores."
+  },
+  "premium.finalCta.cta": {
+    "message": "Activar Premium ahora"
+  },
+  "commands.copy.label": {
+    "message": "Copier la commande",
+    "description": "Aria-label of the copy button on command cells"
+  },
+  "theme.docs.sidebar.versionLabel": {
+    "message": "Version",
+    "description": "Label of the version selector in the docs sidebar"
+  },
+  "editor.sidebar.title": {
+    "message": "Files"
+  },
+  "editor.contribute.title": {
+    "message": "Contribute to the documentation"
+  },
+  "editor.contribute.description": {
+    "message": "Help improve the documentation by editing existing pages. Choose a page below or search for one."
+  },
+  "editor.contribute.searchPlaceholder": {
+    "message": "Search for a page..."
+  },
+  "editor.contribute.noResults": {
+    "message": "No pages found."
+  },
+  "editor.contribute.featured": {
+    "message": "Suggested pages"
+  },
+  "premium.tier.founder.price": {
+    "message": "2,99 $"
   }
 }

--- a/i18n/es/docusaurus-theme-classic/footer.json
+++ b/i18n/es/docusaurus-theme-classic/footer.json
@@ -21,7 +21,7 @@
   },
   "link.item.label.Documentation": {
     "message": "Documentación",
-    "description": "The label of footer link with label=Documentation linking to /"
+    "description": "The label of footer link with label=Documentation linking to /docs"
   },
   "link.item.label.Suggestions": {
     "message": "Sugerencias",
@@ -29,7 +29,7 @@
   },
   "link.item.label.Mentions légales": {
     "message": "Aviso legal",
-    "description": "The label of footer link with label=Mentions légales linking to legal"
+    "description": "The label of footer link with label=Mentions légales linking to /legal"
   },
   "link.item.label.Statuts des services": {
     "message": "Estado de los servicios",
@@ -41,14 +41,14 @@
   },
   "link.item.label.Conditions d'utilisation": {
     "message": "Condiciones de uso",
-    "description": "The label of footer link with label=Conditions d'utilisation linking to terms"
+    "description": "The label of footer link with label=Conditions d'utilisation linking to /terms"
   },
   "link.item.label.Politique de confidentialité": {
     "message": "Política de privacidad",
-    "description": "The label of footer link with label=Politique de confidentialité linking to privacy"
+    "description": "The label of footer link with label=Politique de confidentialité linking to /privacy"
   },
   "link.item.label.Politique des cookies": {
     "message": "Política de cookies",
-    "description": "The label of footer link with label=Politique des cookies linking to cookies"
+    "description": "The label of footer link with label=Politique des cookies linking to /cookies"
   }
 }

--- a/i18n/es/docusaurus-theme-classic/navbar.json
+++ b/i18n/es/docusaurus-theme-classic/navbar.json
@@ -18,5 +18,9 @@
   "item.label.Blog": {
     "message": "Blog",
     "description": "Navbar item with label Blog"
+  },
+  "item.label.Premium": {
+    "message": "Premium",
+    "description": "Navbar item with label Premium"
   }
 }

--- a/i18n/fr/code.json
+++ b/i18n/fr/code.json
@@ -866,5 +866,282 @@
   "permission.moveMembers": {
     "message": "Déplacer des membres",
     "description": "Discord permission name"
+  },
+  "premium.feature.customize.title": {
+    "message": "Personnalisation totale du bot"
+  },
+  "premium.feature.customize.desc": {
+    "message": "Avatar, bannière, pseudo et style d'écriture : RaidProtect prend l'identité de votre serveur."
+  },
+  "premium.feature.authManager.title": {
+    "message": "Authentication Manager étendu"
+  },
+  "premium.feature.authManager.desc": {
+    "message": "Plus de rôles protégés, plus d'utilisateurs autorisés et des sessions deux fois plus longues."
+  },
+  "premium.feature.sanctionNames.title": {
+    "message": "Noms de sanctions personnalisables"
+  },
+  "premium.feature.sanctionNames.desc": {
+    "message": "Adaptez chaque sanction au vocabulaire de votre communauté."
+  },
+  "premium.feature.display.title": {
+    "message": "Plus de panneaux d'information"
+  },
+  "premium.feature.display.desc": {
+    "message": "Deux fois plus de panneaux libres avec /display public (2 → 4), slot Jail toujours inclus."
+  },
+  "premium.feature.honeypot.title": {
+    "message": "Sanctions Honeypot avancées"
+  },
+  "premium.feature.honeypot.desc": {
+    "message": "Débloquez Kick, Timeout, Jail et Mute dans le module HoneyPot."
+  },
+  "premium.experiment.badge.publicBeta": {
+    "message": "Bêta publique"
+  },
+  "premium.experiment.automod.title": {
+    "message": "Conversion AutoMod en mute par rôle"
+  },
+  "premium.experiment.automod.desc": {
+    "message": "Les timeouts appliqués par l'AutoMod de Discord sont automatiquement convertis en mute par rôle au-delà du seuil configuré, pour une cohérence totale avec vos sanctions manuelles."
+  },
+  "premium.experiment.badge.soon": {
+    "message": "Bientôt"
+  },
+  "premium.experiment.more.title": {
+    "message": "D'autres expérimentations à venir"
+  },
+  "premium.experiment.more.desc": {
+    "message": "Les abonnés Premium reçoivent en avant-première les fonctionnalités en bêta publique. Nous publions ici la liste à jour à mesure qu'elles arrivent."
+  },
+  "premium.tier.free.name": {
+    "message": "Basic"
+  },
+  "premium.tier.free.tagline": {
+    "message": "La sécurité essentielle, gratuite pour toujours."
+  },
+  "premium.tier.free.price": {
+    "message": "Gratuit"
+  },
+  "premium.tier.free.cta": {
+    "message": "Ajouter à Discord"
+  },
+  "premium.tier.founder.name": {
+    "message": "Founder"
+  },
+  "premium.tier.founder.tagline": {
+    "message": "Offre de lancement réservée aux premiers abonnés."
+  },
+  "premium.tier.founder.priceUnit": {
+    "message": "/ mois"
+  },
+  "premium.tier.founder.cta": {
+    "message": "S'abonner via Discord"
+  },
+  "premium.tier.business.name": {
+    "message": "Business"
+  },
+  "premium.tier.business.tagline": {
+    "message": "Pour les projets aux exigences de sécurité élevées."
+  },
+  "premium.tier.business.price": {
+    "message": "Sur demande"
+  },
+  "premium.tier.business.cta": {
+    "message": "Prendre rendez-vous"
+  },
+  "premium.compare.included": {
+    "message": "Inclus"
+  },
+  "premium.compare.notIncluded": {
+    "message": "Non inclus"
+  },
+  "premium.compare.custom": {
+    "message": "Custom"
+  },
+  "premium.compare.cat.essential": {
+    "message": "Protection essentielle"
+  },
+  "premium.compare.row.antispam": {
+    "message": "Anti-spam adaptatif"
+  },
+  "premium.compare.row.captcha": {
+    "message": "Captcha & vérification"
+  },
+  "premium.compare.row.antiraid": {
+    "message": "Anti-raid automatique"
+  },
+  "premium.compare.row.antiscam": {
+    "message": "Anti-Scam & ScamLens"
+  },
+  "premium.compare.row.moderation": {
+    "message": "Modération complète (ban, kick, mute, jail…)"
+  },
+  "premium.compare.cat.authManager": {
+    "message": "Authentication Manager"
+  },
+  "premium.compare.row.protectedRoles": {
+    "message": "Rôles protégés"
+  },
+  "premium.compare.row.authorizedUsers": {
+    "message": "Utilisateurs autorisés"
+  },
+  "premium.compare.row.sessionDuration": {
+    "message": "Durée de session"
+  },
+  "premium.compare.cat.display": {
+    "message": "Display public"
+  },
+  "premium.compare.row.panels": {
+    "message": "Panneaux d'information"
+  },
+  "premium.compare.row.panels.free": {
+    "message": "2 + 1 Jail"
+  },
+  "premium.compare.row.panels.founder": {
+    "message": "4 + 1 Jail"
+  },
+  "premium.compare.cat.honeypot": {
+    "message": "HoneyPot"
+  },
+  "premium.compare.row.banSoftban": {
+    "message": "Bannissement & softban"
+  },
+  "premium.compare.row.kickTimeout": {
+    "message": "Kick, Timeout, Jail, Mute"
+  },
+  "premium.compare.cat.customization": {
+    "message": "Personnalisation"
+  },
+  "premium.compare.row.botIdentity": {
+    "message": "Pseudo, avatar et bannière du bot"
+  },
+  "premium.compare.row.nameStyle": {
+    "message": "Style d'écriture du nom (8 polices, 4 effets)"
+  },
+  "premium.compare.row.customSanctions": {
+    "message": "Noms de sanctions personnalisés"
+  },
+  "premium.compare.row.bio": {
+    "message": "Bio personnalisable"
+  },
+  "premium.compare.row.dedicatedInstance": {
+    "message": "Instance dédiée et isolée"
+  },
+  "premium.compare.cat.support": {
+    "message": "Accompagnement"
+  },
+  "premium.compare.row.communitySupport": {
+    "message": "Support communautaire"
+  },
+  "premium.compare.row.betaAccess": {
+    "message": "Accès aux fonctionnalités en bêta publique"
+  },
+  "premium.compare.row.exclusiveRole": {
+    "message": "Rôle exclusif sur le serveur RaidProtect"
+  },
+  "premium.compare.row.prioritySupport": {
+    "message": "Support prioritaire"
+  },
+  "premium.compare.row.audit": {
+    "message": "Audit initial du serveur"
+  },
+  "premium.compare.row.customIntegration": {
+    "message": "Intégration sur mesure"
+  },
+  "premium.compare.row.expertFollowup": {
+    "message": "Suivi régulier avec un expert"
+  },
+  "premium.layout.title": {
+    "message": "Premium"
+  },
+  "premium.layout.description": {
+    "message": "Découvrez RaidProtect Premium : personnalisation du bot, Authentication Manager étendu, sanctions HoneyPot avancées, accès aux fonctionnalités en bêta publique."
+  },
+  "premium.hero.title.line1": {
+    "message": "Une protection à votre image,",
+    "description": "Première ligne du titre du hero premium"
+  },
+  "premium.hero.title.accent": {
+    "message": "sans compromis",
+    "description": "Partie accentuée du titre du hero premium"
+  },
+  "premium.hero.subtitle": {
+    "message": "Débloquez les fonctionnalités avancées de RaidProtect : personnalisation totale, limites étendues sur les modules clés, sanctions sur-mesure et accès anticipé aux nouveautés."
+  },
+  "premium.hero.cta.subscribe": {
+    "message": "S'abonner pour 2,99 $/mois"
+  },
+  "premium.hero.cta.compare": {
+    "message": "Comparer les offres"
+  },
+  "premium.stats.servers": {
+    "message": "Serveurs protégés"
+  },
+  "premium.stats.users": {
+    "message": "Utilisateurs surveillés"
+  },
+  "premium.stats.captcha": {
+    "message": "Captchas résolus"
+  },
+  "premium.stats.antispam": {
+    "message": "Messages anti-spam filtrés"
+  },
+  "premium.servers.title": {
+    "message": "Ils nous font confiance"
+  },
+  "premium.features.eyebrow": {
+    "message": "Ce que vous débloquez"
+  },
+  "premium.features.title": {
+    "message": "Les avantages clés du Premium"
+  },
+  "premium.features.subtitle": {
+    "message": "Cinq leviers concrets pour aller plus loin avec RaidProtect, sans changer votre manière de travailler."
+  },
+  "premium.cta.subscribe": {
+    "message": "S'abonner"
+  },
+  "premium.experiments.eyebrow": {
+    "message": "Programme d'innovation"
+  },
+  "premium.experiments.title": {
+    "message": "Des fonctionnalités en bêta publique"
+  },
+  "premium.experiments.subtitle": {
+    "message": "Les abonnés reçoivent en avant-première les nouveautés en cours de stabilisation. Ces accès évoluent à chaque mise à jour du bot."
+  },
+  "premium.experiment.learnMore": {
+    "message": "En savoir plus →"
+  },
+  "premium.compare.eyebrow": {
+    "message": "Comparatif des offres"
+  },
+  "premium.compare.title": {
+    "message": "Choisissez l'offre qui vous correspond"
+  },
+  "premium.compare.subtitle": {
+    "message": "Toutes les protections essentielles restent gratuites. Le Premium ouvre la personnalisation et les limites étendues. Le Business apporte une instance dédiée et un accompagnement humain."
+  },
+  "premium.finalCta.title": {
+    "message": "Prêt à passer en Premium ?"
+  },
+  "premium.finalCta.subtitle": {
+    "message": "L'offre Founder est limitée dans le temps : 2,99 $/mois à vie pour les premiers abonnés."
+  },
+  "premium.finalCta.cta": {
+    "message": "Activer le Premium maintenant"
+  },
+  "commands.copy.label": {
+    "message": "Copier la commande",
+    "description": "Aria-label of the copy button on command cells"
+  },
+  "theme.docs.sidebar.versionLabel": {
+    "message": "Version",
+    "description": "Label of the version selector in the docs sidebar"
+  },
+  "premium.tier.founder.price": {
+    "message": "2,99 $"
   }
 }

--- a/i18n/fr/docusaurus-theme-classic/footer.json
+++ b/i18n/fr/docusaurus-theme-classic/footer.json
@@ -21,7 +21,7 @@
   },
   "link.item.label.Documentation": {
     "message": "Documentation",
-    "description": "The label of footer link with label=Documentation linking to /"
+    "description": "The label of footer link with label=Documentation linking to /docs"
   },
   "link.item.label.Suggestions": {
     "message": "Suggestions",
@@ -29,7 +29,7 @@
   },
   "link.item.label.Mentions légales": {
     "message": "Mentions légales",
-    "description": "The label of footer link with label=Mentions légales linking to legal"
+    "description": "The label of footer link with label=Mentions légales linking to /legal"
   },
   "link.item.label.Statuts des services": {
     "message": "Statuts des services",
@@ -41,14 +41,14 @@
   },
   "link.item.label.Conditions d'utilisation": {
     "message": "Conditions d'utilisation",
-    "description": "The label of footer link with label=Conditions d'utilisation linking to terms"
+    "description": "The label of footer link with label=Conditions d'utilisation linking to /terms"
   },
   "link.item.label.Politique de confidentialité": {
     "message": "Politique de confidentialité",
-    "description": "The label of footer link with label=Politique de confidentialité linking to privacy"
+    "description": "The label of footer link with label=Politique de confidentialité linking to /privacy"
   },
   "link.item.label.Politique des cookies": {
     "message": "Politique des cookies",
-    "description": "The label of footer link with label=Politique des cookies linking to cookies"
+    "description": "The label of footer link with label=Politique des cookies linking to /cookies"
   }
 }

--- a/i18n/fr/docusaurus-theme-classic/navbar.json
+++ b/i18n/fr/docusaurus-theme-classic/navbar.json
@@ -18,5 +18,9 @@
   "item.label.Blog": {
     "message": "Blog",
     "description": "Navbar item with label Blog"
+  },
+  "item.label.Premium": {
+    "message": "Premium",
+    "description": "Navbar item with label Premium"
   }
 }

--- a/i18n/pt/code.json
+++ b/i18n/pt/code.json
@@ -405,7 +405,8 @@
     "message": "Carregando..."
   },
   "editor.authenticating": {
-    "message": "Autenticando..."
+    "message": "Autenticando...",
+    "description": "Authenticating message"
   },
   "editor.exitBar.backToDocs": {
     "message": "Voltar à documentação"
@@ -446,7 +447,7 @@
   },
   "servers.memberCount": {
     "message": "{count} membros",
-    "description": "Server card: number of members; {count} is locale-formatted"
+    "description": "Server card: number of members (e.g. '40 000 members'); {count} is locale-formatted"
   },
   "frame.cta.title": {
     "message": "Manter-se um passo {highlight}",
@@ -847,5 +848,300 @@
   "permission.moveMembers": {
     "message": "Mover membros",
     "description": "Discord permission name"
+  },
+  "premium.feature.customize.title": {
+    "message": "Personalização total do bot"
+  },
+  "premium.feature.customize.desc": {
+    "message": "Avatar, banner, apelido e estilo de escrita: o RaidProtect assume a identidade do seu servidor."
+  },
+  "premium.feature.authManager.title": {
+    "message": "Authentication Manager ampliado"
+  },
+  "premium.feature.authManager.desc": {
+    "message": "Mais cargos protegidos, mais usuários autorizados e sessões duas vezes mais longas."
+  },
+  "premium.feature.sanctionNames.title": {
+    "message": "Nomes de sanções personalizáveis"
+  },
+  "premium.feature.sanctionNames.desc": {
+    "message": "Adapte cada sanção ao vocabulário da sua comunidade."
+  },
+  "premium.feature.display.title": {
+    "message": "Mais painéis de informação"
+  },
+  "premium.feature.display.desc": {
+    "message": "Duas vezes mais painéis livres com /display public (2 → 4), espaço Jail sempre incluído."
+  },
+  "premium.feature.honeypot.title": {
+    "message": "Sanções Honeypot avançadas"
+  },
+  "premium.feature.honeypot.desc": {
+    "message": "Desbloqueie Kick, Timeout, Jail e Mute no módulo HoneyPot."
+  },
+  "premium.experiment.badge.publicBeta": {
+    "message": "Beta pública"
+  },
+  "premium.experiment.automod.title": {
+    "message": "Conversão de AutoMod em mute por cargo"
+  },
+  "premium.experiment.automod.desc": {
+    "message": "Os timeouts aplicados pelo AutoMod do Discord são automaticamente convertidos em mute por cargo acima do limite configurado, para uma coerência total com suas sanções manuais."
+  },
+  "premium.experiment.badge.soon": {
+    "message": "Em breve"
+  },
+  "premium.experiment.more.title": {
+    "message": "Mais experimentos a caminho"
+  },
+  "premium.experiment.more.desc": {
+    "message": "Os assinantes Premium recebem em primeira mão as funcionalidades em beta pública. Publicamos aqui a lista atualizada à medida que elas chegam."
+  },
+  "premium.tier.free.name": {
+    "message": "Basic"
+  },
+  "premium.tier.free.tagline": {
+    "message": "A segurança essencial, grátis para sempre."
+  },
+  "premium.tier.free.price": {
+    "message": "Grátis"
+  },
+  "premium.tier.free.cta": {
+    "message": "Adicionar ao Discord"
+  },
+  "premium.tier.founder.name": {
+    "message": "Founder"
+  },
+  "premium.tier.founder.tagline": {
+    "message": "Oferta de lançamento reservada aos primeiros assinantes."
+  },
+  "premium.tier.founder.priceUnit": {
+    "message": "/ mês"
+  },
+  "premium.tier.founder.cta": {
+    "message": "Assinar via Discord"
+  },
+  "premium.tier.business.name": {
+    "message": "Business"
+  },
+  "premium.tier.business.tagline": {
+    "message": "Para projetos com altas exigências de segurança."
+  },
+  "premium.tier.business.price": {
+    "message": "Sob consulta"
+  },
+  "premium.tier.business.cta": {
+    "message": "Agendar uma reunião"
+  },
+  "premium.compare.included": {
+    "message": "Incluído"
+  },
+  "premium.compare.notIncluded": {
+    "message": "Não incluído"
+  },
+  "premium.compare.custom": {
+    "message": "Personalizado"
+  },
+  "premium.compare.cat.essential": {
+    "message": "Proteção essencial"
+  },
+  "premium.compare.row.antispam": {
+    "message": "Anti-spam adaptativo"
+  },
+  "premium.compare.row.captcha": {
+    "message": "Captcha e verificação"
+  },
+  "premium.compare.row.antiraid": {
+    "message": "Anti-raid automático"
+  },
+  "premium.compare.row.antiscam": {
+    "message": "Anti-Scam e ScamLens"
+  },
+  "premium.compare.row.moderation": {
+    "message": "Moderação completa (ban, kick, mute, jail…)"
+  },
+  "premium.compare.cat.authManager": {
+    "message": "Authentication Manager"
+  },
+  "premium.compare.row.protectedRoles": {
+    "message": "Cargos protegidos"
+  },
+  "premium.compare.row.authorizedUsers": {
+    "message": "Usuários autorizados"
+  },
+  "premium.compare.row.sessionDuration": {
+    "message": "Duração da sessão"
+  },
+  "premium.compare.cat.display": {
+    "message": "Display público"
+  },
+  "premium.compare.row.panels": {
+    "message": "Painéis de informação"
+  },
+  "premium.compare.row.panels.free": {
+    "message": "2 + 1 Jail"
+  },
+  "premium.compare.row.panels.founder": {
+    "message": "4 + 1 Jail"
+  },
+  "premium.compare.cat.honeypot": {
+    "message": "HoneyPot"
+  },
+  "premium.compare.row.banSoftban": {
+    "message": "Banimento e softban"
+  },
+  "premium.compare.row.kickTimeout": {
+    "message": "Kick, Timeout, Jail, Mute"
+  },
+  "premium.compare.cat.customization": {
+    "message": "Personalização"
+  },
+  "premium.compare.row.botIdentity": {
+    "message": "Apelido, avatar e banner do bot"
+  },
+  "premium.compare.row.nameStyle": {
+    "message": "Estilo do nome (8 fontes, 4 efeitos)"
+  },
+  "premium.compare.row.customSanctions": {
+    "message": "Nomes de sanções personalizados"
+  },
+  "premium.compare.row.bio": {
+    "message": "Bio personalizável"
+  },
+  "premium.compare.row.dedicatedInstance": {
+    "message": "Instância dedicada e isolada"
+  },
+  "premium.compare.cat.support": {
+    "message": "Acompanhamento"
+  },
+  "premium.compare.row.communitySupport": {
+    "message": "Suporte da comunidade"
+  },
+  "premium.compare.row.betaAccess": {
+    "message": "Acesso às funcionalidades em beta pública"
+  },
+  "premium.compare.row.exclusiveRole": {
+    "message": "Cargo exclusivo no servidor do RaidProtect"
+  },
+  "premium.compare.row.prioritySupport": {
+    "message": "Suporte prioritário"
+  },
+  "premium.compare.row.audit": {
+    "message": "Auditoria inicial do servidor"
+  },
+  "premium.compare.row.customIntegration": {
+    "message": "Integração sob medida"
+  },
+  "premium.compare.row.expertFollowup": {
+    "message": "Acompanhamento regular com um especialista"
+  },
+  "premium.layout.title": {
+    "message": "Premium"
+  },
+  "premium.layout.description": {
+    "message": "Descubra o RaidProtect Premium: personalização do bot, Authentication Manager ampliado, sanções HoneyPot avançadas, acesso às funcionalidades em beta pública."
+  },
+  "premium.hero.title.line1": {
+    "message": "Uma proteção à sua imagem,",
+    "description": "Première ligne du titre du hero premium"
+  },
+  "premium.hero.title.accent": {
+    "message": "sem concessões",
+    "description": "Partie accentuée du titre du hero premium"
+  },
+  "premium.hero.subtitle": {
+    "message": "Desbloqueie as funcionalidades avançadas do RaidProtect: personalização total, limites ampliados nos módulos-chave, sanções sob medida e acesso antecipado às novidades."
+  },
+  "premium.hero.cta.subscribe": {
+    "message": "Assinar por 2,99 $/mês"
+  },
+  "premium.hero.cta.compare": {
+    "message": "Comparar planos"
+  },
+  "premium.stats.servers": {
+    "message": "Servidores protegidos"
+  },
+  "premium.stats.users": {
+    "message": "Usuários monitorados"
+  },
+  "premium.stats.captcha": {
+    "message": "Captchas resolvidos"
+  },
+  "premium.stats.antispam": {
+    "message": "Mensagens anti-spam filtradas"
+  },
+  "premium.servers.title": {
+    "message": "Eles confiam em nós"
+  },
+  "premium.features.eyebrow": {
+    "message": "O que você desbloqueia"
+  },
+  "premium.features.title": {
+    "message": "As principais vantagens do Premium"
+  },
+  "premium.features.subtitle": {
+    "message": "Cinco alavancas concretas para ir mais longe com o RaidProtect, sem mudar a sua forma de trabalhar."
+  },
+  "premium.cta.subscribe": {
+    "message": "Assinar"
+  },
+  "premium.experiments.eyebrow": {
+    "message": "Programa de inovação"
+  },
+  "premium.experiments.title": {
+    "message": "Funcionalidades em beta pública"
+  },
+  "premium.experiments.subtitle": {
+    "message": "Os assinantes recebem em primeira mão as novidades em fase de estabilização. Esses acessos evoluem a cada atualização do bot."
+  },
+  "premium.experiment.learnMore": {
+    "message": "Saiba mais →"
+  },
+  "premium.compare.eyebrow": {
+    "message": "Comparativo de planos"
+  },
+  "premium.compare.title": {
+    "message": "Escolha o plano que combina com você"
+  },
+  "premium.compare.subtitle": {
+    "message": "Todas as proteções essenciais continuam gratuitas. O Premium abre a personalização e os limites ampliados. O Business traz uma instância dedicada e um acompanhamento humano."
+  },
+  "premium.finalCta.title": {
+    "message": "Pronto para passar para o Premium?"
+  },
+  "premium.finalCta.subtitle": {
+    "message": "A oferta Founder é por tempo limitado: 2,99 $/mês vitalício para os primeiros assinantes."
+  },
+  "premium.finalCta.cta": {
+    "message": "Ativar o Premium agora"
+  },
+  "commands.copy.label": {
+    "message": "Copier la commande",
+    "description": "Aria-label of the copy button on command cells"
+  },
+  "theme.docs.sidebar.versionLabel": {
+    "message": "Version",
+    "description": "Label of the version selector in the docs sidebar"
+  },
+  "editor.sidebar.title": {
+    "message": "Files"
+  },
+  "editor.contribute.title": {
+    "message": "Contribute to the documentation"
+  },
+  "editor.contribute.description": {
+    "message": "Help improve the documentation by editing existing pages. Choose a page below or search for one."
+  },
+  "editor.contribute.searchPlaceholder": {
+    "message": "Search for a page..."
+  },
+  "editor.contribute.noResults": {
+    "message": "No pages found."
+  },
+  "editor.contribute.featured": {
+    "message": "Suggested pages"
+  },
+  "premium.tier.founder.price": {
+    "message": "2,99 $"
   }
 }

--- a/i18n/pt/docusaurus-theme-classic/footer.json
+++ b/i18n/pt/docusaurus-theme-classic/footer.json
@@ -21,7 +21,7 @@
   },
   "link.item.label.Documentation": {
     "message": "Documentação",
-    "description": "The label of footer link with label=Documentation linking to /"
+    "description": "The label of footer link with label=Documentation linking to /docs"
   },
   "link.item.label.Suggestions": {
     "message": "Sugestões",
@@ -29,7 +29,7 @@
   },
   "link.item.label.Mentions légales": {
     "message": "Aviso legal",
-    "description": "The label of footer link with label=Mentions légales linking to legal"
+    "description": "The label of footer link with label=Mentions légales linking to /legal"
   },
   "link.item.label.Statuts des services": {
     "message": "Estado dos serviços",
@@ -41,14 +41,14 @@
   },
   "link.item.label.Conditions d'utilisation": {
     "message": "Condições de utilização",
-    "description": "The label of footer link with label=Conditions d'utilisation linking to terms"
+    "description": "The label of footer link with label=Conditions d'utilisation linking to /terms"
   },
   "link.item.label.Politique de confidentialité": {
     "message": "Política de privacidade",
-    "description": "The label of footer link with label=Politique de confidentialité linking to privacy"
+    "description": "The label of footer link with label=Politique de confidentialité linking to /privacy"
   },
   "link.item.label.Politique des cookies": {
     "message": "Política de Cookies",
-    "description": "The label of footer link with label=Politique des cookies linking to cookies"
+    "description": "The label of footer link with label=Politique des cookies linking to /cookies"
   }
 }

--- a/i18n/pt/docusaurus-theme-classic/navbar.json
+++ b/i18n/pt/docusaurus-theme-classic/navbar.json
@@ -18,5 +18,9 @@
   "item.label.Blog": {
     "message": "Blog",
     "description": "Navbar item with label Blog"
+  },
+  "item.label.Premium": {
+    "message": "Premium",
+    "description": "Navbar item with label Premium"
   }
 }

--- a/src/pages/premium.tsx
+++ b/src/pages/premium.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import Layout from '@theme/Layout'
 import Head from '@docusaurus/Head'
 import Link from '@docusaurus/Link'
+import Translate, { translate } from '@docusaurus/Translate'
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
 
 import { localizedRedirectUrl } from '@site/src/utils/links'
@@ -14,34 +15,6 @@ type FeatureCard = {
     description: string
 }
 
-const HEADLINE_FEATURES: FeatureCard[] = [
-    {
-        icon: '/img/icons/iconCustomizeWhite.svg',
-        title: 'Personnalisation totale du bot',
-        description: 'Avatar, bannière, pseudo et style d\'écriture : RaidProtect prend l\'identité de votre serveur.',
-    },
-    {
-        icon: '/img/icons/iconAuthManagerWhite.svg',
-        title: 'Authentication Manager étendu',
-        description: 'Plus de rôles protégés, plus d\'utilisateurs autorisés et des sessions deux fois plus longues.',
-    },
-    {
-        icon: '/img/icons/iconCustomWhite.svg',
-        title: 'Noms de sanctions personnalisables',
-        description: 'Adaptez chaque sanction au vocabulaire de votre communauté.',
-    },
-    {
-        icon: '/img/icons/iconDisplayWhite.svg',
-        title: 'Plus de panneaux d\'information',
-        description: 'Deux fois plus de panneaux libres avec /display public (2 → 4), slot Jail toujours inclus.',
-    },
-    {
-        icon: '/img/icons/iconHoneyPotWhite.svg',
-        title: 'Sanctions Honeypot avancées',
-        description: 'Débloquez Kick, Timeout, Jail et Mute dans le module HoneyPot.',
-    },
-]
-
 type ExperimentCard = {
     icon: string
     badge: string
@@ -49,22 +22,6 @@ type ExperimentCard = {
     description: string
     docsHref?: string
 }
-
-const EXPERIMENTS: ExperimentCard[] = [
-    {
-        icon: '/img/icons/SanctionsTIMEOUT.svg',
-        badge: 'Bêta publique',
-        title: 'Conversion AutoMod en mute par rôle',
-        description: 'Les timeouts appliqués par l\'AutoMod de Discord sont automatiquement convertis en mute par rôle au-delà du seuil configuré, pour une cohérence totale avec vos sanctions manuelles.',
-        docsHref: '/docs/features/sanctions#mute-threshold',
-    },
-    {
-        icon: '/img/icons/iconBetaWhite.svg',
-        badge: 'Bientôt',
-        title: 'D\'autres expérimentations à venir',
-        description: 'Les abonnés Premium reçoivent en avant-première les fonctionnalités en bêta publique. Nous publions ici la liste à jour à mesure qu\'elles arrivent.',
-    },
-]
 
 type Tier = {
     id: string
@@ -76,75 +33,9 @@ type Tier = {
     highlight?: boolean
 }
 
-const TIERS: Tier[] = [
-    {
-        id: 'free',
-        name: 'Basic',
-        tagline: 'La sécurité essentielle, gratuite pour toujours.',
-        price: 'Gratuit',
-        cta: { label: 'Ajouter à Discord', href: '/invite' },
-    },
-    {
-        id: 'premium',
-        name: 'Founder',
-        tagline: 'Offre de lancement réservée aux premiers abonnés.',
-        price: '2,99 $',
-        priceUnit: '/ mois',
-        cta: { label: 'S\'abonner via Discord', href: 'https://raidprotect.bot/founder', primary: true },
-        highlight: true,
-    },
-    {
-        id: 'enterprise',
-        name: 'Business',
-        tagline: 'Pour les projets aux exigences de sécurité élevées.',
-        price: 'Sur demande',
-        cta: { label: 'Prendre rendez-vous', href: '/appointment' },
-    },
-]
-
 type Row =
     | { type: 'category'; label: string }
     | { type: 'feature'; label: string; values: [React.ReactNode, React.ReactNode, React.ReactNode] }
-
-const yes = <span className={styles.checkYes} aria-label="Inclus">✓</span>
-const no  = <span className={styles.checkNo} aria-label="Non inclus">✗</span>
-
-const COMPARE_ROWS: Row[] = [
-    { type: 'category', label: 'Protection essentielle' },
-    { type: 'feature', label: 'Anti-spam adaptatif', values: [yes, yes, yes] },
-    { type: 'feature', label: 'Captcha & vérification', values: [yes, yes, yes] },
-    { type: 'feature', label: 'Anti-raid automatique', values: [yes, yes, yes] },
-    { type: 'feature', label: 'Anti-Scam & ScamLens', values: [yes, yes, yes] },
-    { type: 'feature', label: 'Modération complète (ban, kick, mute, jail…)', values: [yes, yes, yes] },
-
-    { type: 'category', label: 'Authentication Manager' },
-    { type: 'feature', label: 'Rôles protégés', values: ['3', '10', 'Custom'] },
-    { type: 'feature', label: 'Utilisateurs autorisés', values: ['20', '50', 'Custom'] },
-    { type: 'feature', label: 'Durée de session', values: ['8 h', '24 h', 'Custom'] },
-
-    { type: 'category', label: 'Display public' },
-    { type: 'feature', label: 'Panneaux d\'information', values: ['2 + 1 Jail', '4 + 1 Jail', 'Custom'] },
-
-    { type: 'category', label: 'HoneyPot' },
-    { type: 'feature', label: 'Bannissement & softban', values: [yes, yes, yes] },
-    { type: 'feature', label: 'Kick, Timeout, Jail, Mute', values: [no, yes, yes] },
-
-    { type: 'category', label: 'Personnalisation' },
-    { type: 'feature', label: 'Pseudo, avatar et bannière du bot', values: [no, yes, yes] },
-    { type: 'feature', label: 'Style d\'écriture du nom (8 polices, 4 effets)', values: [no, yes, yes] },
-    { type: 'feature', label: 'Noms de sanctions personnalisés', values: [no, yes, yes] },
-    { type: 'feature', label: 'Bio personnalisable', values: [no, no, yes] },
-    { type: 'feature', label: 'Instance dédiée et isolée', values: [no, no, yes] },
-
-    { type: 'category', label: 'Accompagnement' },
-    { type: 'feature', label: 'Support communautaire', values: [yes, yes, yes] },
-    { type: 'feature', label: 'Accès aux fonctionnalités en bêta publique', values: [no, yes, yes] },
-    { type: 'feature', label: 'Rôle exclusif sur le serveur RaidProtect', values: [no, yes, yes] },
-    { type: 'feature', label: 'Support prioritaire', values: [no, no, yes] },
-    { type: 'feature', label: 'Audit initial du serveur', values: [no, no, yes] },
-    { type: 'feature', label: 'Intégration sur mesure', values: [no, no, yes] },
-    { type: 'feature', label: 'Suivi régulier avec un expert', values: [no, no, yes] },
-]
 
 type Stats = {
     servers: number
@@ -309,11 +200,131 @@ export default function PremiumPage(): React.ReactNode {
         }
     }, [])
 
+    // Les données textuelles sont construites au rendu pour que translate()
+    // lise la locale courante (des constantes au niveau module seraient figées).
+    const HEADLINE_FEATURES: FeatureCard[] = [
+        {
+            icon: '/img/icons/iconCustomizeWhite.svg',
+            title: translate({ id: 'premium.feature.customize.title', message: 'Personnalisation totale du bot' }),
+            description: translate({ id: 'premium.feature.customize.desc', message: 'Avatar, bannière, pseudo et style d\'écriture : RaidProtect prend l\'identité de votre serveur.' }),
+        },
+        {
+            icon: '/img/icons/iconAuthManagerWhite.svg',
+            title: translate({ id: 'premium.feature.authManager.title', message: 'Authentication Manager étendu' }),
+            description: translate({ id: 'premium.feature.authManager.desc', message: 'Plus de rôles protégés, plus d\'utilisateurs autorisés et des sessions deux fois plus longues.' }),
+        },
+        {
+            icon: '/img/icons/iconCustomWhite.svg',
+            title: translate({ id: 'premium.feature.sanctionNames.title', message: 'Noms de sanctions personnalisables' }),
+            description: translate({ id: 'premium.feature.sanctionNames.desc', message: 'Adaptez chaque sanction au vocabulaire de votre communauté.' }),
+        },
+        {
+            icon: '/img/icons/iconDisplayWhite.svg',
+            title: translate({ id: 'premium.feature.display.title', message: 'Plus de panneaux d\'information' }),
+            description: translate({ id: 'premium.feature.display.desc', message: 'Deux fois plus de panneaux libres avec /display public (2 → 4), slot Jail toujours inclus.' }),
+        },
+        {
+            icon: '/img/icons/iconHoneyPotWhite.svg',
+            title: translate({ id: 'premium.feature.honeypot.title', message: 'Sanctions Honeypot avancées' }),
+            description: translate({ id: 'premium.feature.honeypot.desc', message: 'Débloquez Kick, Timeout, Jail et Mute dans le module HoneyPot.' }),
+        },
+    ]
+
+    const EXPERIMENTS: ExperimentCard[] = [
+        {
+            icon: '/img/icons/SanctionsTIMEOUT.svg',
+            badge: translate({ id: 'premium.experiment.badge.publicBeta', message: 'Bêta publique' }),
+            title: translate({ id: 'premium.experiment.automod.title', message: 'Conversion AutoMod en mute par rôle' }),
+            description: translate({ id: 'premium.experiment.automod.desc', message: 'Les timeouts appliqués par l\'AutoMod de Discord sont automatiquement convertis en mute par rôle au-delà du seuil configuré, pour une cohérence totale avec vos sanctions manuelles.' }),
+            docsHref: '/docs/features/sanctions#mute-threshold',
+        },
+        {
+            icon: '/img/icons/iconBetaWhite.svg',
+            badge: translate({ id: 'premium.experiment.badge.soon', message: 'Bientôt' }),
+            title: translate({ id: 'premium.experiment.more.title', message: 'D\'autres expérimentations à venir' }),
+            description: translate({ id: 'premium.experiment.more.desc', message: 'Les abonnés Premium reçoivent en avant-première les fonctionnalités en bêta publique. Nous publions ici la liste à jour à mesure qu\'elles arrivent.' }),
+        },
+    ]
+
+    const TIERS: Tier[] = [
+        {
+            id: 'free',
+            name: translate({ id: 'premium.tier.free.name', message: 'Basic' }),
+            tagline: translate({ id: 'premium.tier.free.tagline', message: 'La sécurité essentielle, gratuite pour toujours.' }),
+            price: translate({ id: 'premium.tier.free.price', message: 'Gratuit' }),
+            cta: { label: translate({ id: 'premium.tier.free.cta', message: 'Ajouter à Discord' }), href: '/invite' },
+        },
+        {
+            id: 'premium',
+            name: translate({ id: 'premium.tier.founder.name', message: 'Founder' }),
+            tagline: translate({ id: 'premium.tier.founder.tagline', message: 'Offre de lancement réservée aux premiers abonnés.' }),
+            price: translate({ id: 'premium.tier.founder.price', message: '2,99 $' }),
+            priceUnit: translate({ id: 'premium.tier.founder.priceUnit', message: '/ mois' }),
+            cta: { label: translate({ id: 'premium.tier.founder.cta', message: 'S\'abonner via Discord' }), href: 'https://raidprotect.bot/founder', primary: true },
+            highlight: true,
+        },
+        {
+            id: 'enterprise',
+            name: translate({ id: 'premium.tier.business.name', message: 'Business' }),
+            tagline: translate({ id: 'premium.tier.business.tagline', message: 'Pour les projets aux exigences de sécurité élevées.' }),
+            price: translate({ id: 'premium.tier.business.price', message: 'Sur demande' }),
+            cta: { label: translate({ id: 'premium.tier.business.cta', message: 'Prendre rendez-vous' }), href: '/appointment' },
+        },
+    ]
+
+    const yes = <span className={styles.checkYes} aria-label={translate({ id: 'premium.compare.included', message: 'Inclus' })}>✓</span>
+    const no  = <span className={styles.checkNo} aria-label={translate({ id: 'premium.compare.notIncluded', message: 'Non inclus' })}>✗</span>
+    const custom = translate({ id: 'premium.compare.custom', message: 'Custom' })
+
+    const COMPARE_ROWS: Row[] = [
+        { type: 'category', label: translate({ id: 'premium.compare.cat.essential', message: 'Protection essentielle' }) },
+        { type: 'feature', label: translate({ id: 'premium.compare.row.antispam', message: 'Anti-spam adaptatif' }), values: [yes, yes, yes] },
+        { type: 'feature', label: translate({ id: 'premium.compare.row.captcha', message: 'Captcha & vérification' }), values: [yes, yes, yes] },
+        { type: 'feature', label: translate({ id: 'premium.compare.row.antiraid', message: 'Anti-raid automatique' }), values: [yes, yes, yes] },
+        { type: 'feature', label: translate({ id: 'premium.compare.row.antiscam', message: 'Anti-Scam & ScamLens' }), values: [yes, yes, yes] },
+        { type: 'feature', label: translate({ id: 'premium.compare.row.moderation', message: 'Modération complète (ban, kick, mute, jail…)' }), values: [yes, yes, yes] },
+
+        { type: 'category', label: translate({ id: 'premium.compare.cat.authManager', message: 'Authentication Manager' }) },
+        { type: 'feature', label: translate({ id: 'premium.compare.row.protectedRoles', message: 'Rôles protégés' }), values: ['3', '10', custom] },
+        { type: 'feature', label: translate({ id: 'premium.compare.row.authorizedUsers', message: 'Utilisateurs autorisés' }), values: ['20', '50', custom] },
+        { type: 'feature', label: translate({ id: 'premium.compare.row.sessionDuration', message: 'Durée de session' }), values: ['8 h', '24 h', custom] },
+
+        { type: 'category', label: translate({ id: 'premium.compare.cat.display', message: 'Display public' }) },
+        { type: 'feature', label: translate({ id: 'premium.compare.row.panels', message: 'Panneaux d\'information' }), values: [
+            translate({ id: 'premium.compare.row.panels.free', message: '2 + 1 Jail' }),
+            translate({ id: 'premium.compare.row.panels.founder', message: '4 + 1 Jail' }),
+            custom,
+        ] },
+
+        { type: 'category', label: translate({ id: 'premium.compare.cat.honeypot', message: 'HoneyPot' }) },
+        { type: 'feature', label: translate({ id: 'premium.compare.row.banSoftban', message: 'Bannissement & softban' }), values: [yes, yes, yes] },
+        { type: 'feature', label: translate({ id: 'premium.compare.row.kickTimeout', message: 'Kick, Timeout, Jail, Mute' }), values: [no, yes, yes] },
+
+        { type: 'category', label: translate({ id: 'premium.compare.cat.customization', message: 'Personnalisation' }) },
+        { type: 'feature', label: translate({ id: 'premium.compare.row.botIdentity', message: 'Pseudo, avatar et bannière du bot' }), values: [no, yes, yes] },
+        { type: 'feature', label: translate({ id: 'premium.compare.row.nameStyle', message: 'Style d\'écriture du nom (8 polices, 4 effets)' }), values: [no, yes, yes] },
+        { type: 'feature', label: translate({ id: 'premium.compare.row.customSanctions', message: 'Noms de sanctions personnalisés' }), values: [no, yes, yes] },
+        { type: 'feature', label: translate({ id: 'premium.compare.row.bio', message: 'Bio personnalisable' }), values: [no, no, yes] },
+        { type: 'feature', label: translate({ id: 'premium.compare.row.dedicatedInstance', message: 'Instance dédiée et isolée' }), values: [no, no, yes] },
+
+        { type: 'category', label: translate({ id: 'premium.compare.cat.support', message: 'Accompagnement' }) },
+        { type: 'feature', label: translate({ id: 'premium.compare.row.communitySupport', message: 'Support communautaire' }), values: [yes, yes, yes] },
+        { type: 'feature', label: translate({ id: 'premium.compare.row.betaAccess', message: 'Accès aux fonctionnalités en bêta publique' }), values: [no, yes, yes] },
+        { type: 'feature', label: translate({ id: 'premium.compare.row.exclusiveRole', message: 'Rôle exclusif sur le serveur RaidProtect' }), values: [no, yes, yes] },
+        { type: 'feature', label: translate({ id: 'premium.compare.row.prioritySupport', message: 'Support prioritaire' }), values: [no, no, yes] },
+        { type: 'feature', label: translate({ id: 'premium.compare.row.audit', message: 'Audit initial du serveur' }), values: [no, no, yes] },
+        { type: 'feature', label: translate({ id: 'premium.compare.row.customIntegration', message: 'Intégration sur mesure' }), values: [no, no, yes] },
+        { type: 'feature', label: translate({ id: 'premium.compare.row.expertFollowup', message: 'Suivi régulier avec un expert' }), values: [no, no, yes] },
+    ]
+
+    const layoutTitle = translate({ id: 'premium.layout.title', message: 'Premium' })
+    const layoutDescription = translate({
+        id: 'premium.layout.description',
+        message: 'Découvrez RaidProtect Premium : personnalisation du bot, Authentication Manager étendu, sanctions HoneyPot avancées, accès aux fonctionnalités en bêta publique.',
+    })
+
     return (
-        <Layout
-            title="Premium"
-            description="Découvrez RaidProtect Premium : personnalisation du bot, Authentication Manager étendu, sanctions HoneyPot avancées, accès aux fonctionnalités en bêta publique."
-        >
+        <Layout title={layoutTitle} description={layoutDescription}>
             {/* Rend la navbar transparente sur cette page (cf. custom.css). */}
             <Head>
                 <body className="premium-page" />
@@ -323,20 +334,26 @@ export default function PremiumPage(): React.ReactNode {
                 <section className={styles.hero}>
                     <div className={styles.container}>
                         <h1 className={styles.heroTitle}>
-                            Une protection à votre image,
-                            <span className={styles.heroTitleAccent}>sans compromis</span>
+                            <Translate id="premium.hero.title.line1" description="Première ligne du titre du hero premium">
+                                Une protection à votre image,
+                            </Translate>
+                            <span className={styles.heroTitleAccent}>
+                                <Translate id="premium.hero.title.accent" description="Partie accentuée du titre du hero premium">
+                                    sans compromis
+                                </Translate>
+                            </span>
                         </h1>
                         <p className={styles.heroSubtitle}>
-                            Débloquez les fonctionnalités avancées de RaidProtect : personnalisation totale,
-                            limites étendues sur les modules clés, sanctions sur-mesure et accès anticipé
-                            aux nouveautés.
+                            <Translate id="premium.hero.subtitle">
+                                Débloquez les fonctionnalités avancées de RaidProtect : personnalisation totale, limites étendues sur les modules clés, sanctions sur-mesure et accès anticipé aux nouveautés.
+                            </Translate>
                         </p>
                         <div className={styles.heroCtas}>
                             <Link to="https://raidprotect.bot/founder" className={`${styles.ctaPrimary} ${styles.ctaGlow}`}>
-                                S'abonner pour 2,99 $/mois
+                                <Translate id="premium.hero.cta.subscribe">S'abonner pour 2,99 $/mois</Translate>
                             </Link>
                             <a href="#compare" className={styles.ctaSecondary}>
-                                Comparer les offres
+                                <Translate id="premium.hero.cta.compare">Comparer les offres</Translate>
                             </a>
                         </div>
                     </div>
@@ -346,34 +363,39 @@ export default function PremiumPage(): React.ReactNode {
                 <section className={styles.statsSection}>
                     <div className={styles.container}>
                         <div className={styles.statsGrid}>
-                            <StatCard value={stats.servers} label="Serveurs protégés" />
-                            <StatCard value={stats.users} label="Utilisateurs surveillés" />
-                            <StatCard value={stats.captcha} label="Captchas résolus" />
-                            <StatCard value={stats.antispam} label="Messages anti-spam filtrés" />
+                            <StatCard value={stats.servers} label={translate({ id: 'premium.stats.servers', message: 'Serveurs protégés' })} />
+                            <StatCard value={stats.users} label={translate({ id: 'premium.stats.users', message: 'Utilisateurs surveillés' })} />
+                            <StatCard value={stats.captcha} label={translate({ id: 'premium.stats.captcha', message: 'Captchas résolus' })} />
+                            <StatCard value={stats.antispam} label={translate({ id: 'premium.stats.antispam', message: 'Messages anti-spam filtrés' })} />
                         </div>
                     </div>
                 </section>
 
                 {/* ============= ILS NOUS FONT CONFIANCE ============= */}
-                <Servers title="Ils nous font confiance" transparent />
+                <Servers title={translate({ id: 'premium.servers.title', message: 'Ils nous font confiance' })} transparent />
 
                 {/* ============= AVANTAGES PRINCIPAUX ============= */}
                 <section className={styles.section}>
                     <div className={styles.container}>
                         <div className={styles.sectionHead}>
                             <div>
-                                <span className={styles.sectionEyebrow}>Ce que vous débloquez</span>
-                                <h2 className={styles.sectionTitle}>Les avantages clés du Premium</h2>
+                                <span className={styles.sectionEyebrow}>
+                                    <Translate id="premium.features.eyebrow">Ce que vous débloquez</Translate>
+                                </span>
+                                <h2 className={styles.sectionTitle}>
+                                    <Translate id="premium.features.title">Les avantages clés du Premium</Translate>
+                                </h2>
                                 <p className={styles.sectionSubtitle}>
-                                    Cinq leviers concrets pour aller plus loin avec RaidProtect, sans changer
-                                    votre manière de travailler.
+                                    <Translate id="premium.features.subtitle">
+                                        Cinq leviers concrets pour aller plus loin avec RaidProtect, sans changer votre manière de travailler.
+                                    </Translate>
                                 </p>
                             </div>
                             <Link
                                 to="https://raidprotect.bot/founder"
                                 className={`${styles.ctaPrimary} ${styles.ctaGlow} ${styles.sectionHeadCta}`}
                             >
-                                S'abonner
+                                <Translate id="premium.cta.subscribe">S'abonner</Translate>
                             </Link>
                         </div>
                         <div className={styles.grid}>
@@ -398,20 +420,23 @@ export default function PremiumPage(): React.ReactNode {
                     <div className={styles.container}>
                         <div className={styles.sectionHead}>
                             <div>
-                                <span className={styles.sectionEyebrow}>Programme d'innovation</span>
+                                <span className={styles.sectionEyebrow}>
+                                    <Translate id="premium.experiments.eyebrow">Programme d'innovation</Translate>
+                                </span>
                                 <h2 className={styles.sectionTitle}>
-                                    Des fonctionnalités en bêta publique
+                                    <Translate id="premium.experiments.title">Des fonctionnalités en bêta publique</Translate>
                                 </h2>
                                 <p className={styles.sectionSubtitle}>
-                                    Les abonnés reçoivent en avant-première les nouveautés en cours de
-                                    stabilisation. Ces accès évoluent à chaque mise à jour du bot.
+                                    <Translate id="premium.experiments.subtitle">
+                                        Les abonnés reçoivent en avant-première les nouveautés en cours de stabilisation. Ces accès évoluent à chaque mise à jour du bot.
+                                    </Translate>
                                 </p>
                             </div>
                             <Link
                                 to="https://raidprotect.bot/founder"
                                 className={`${styles.ctaPrimary} ${styles.ctaGlow} ${styles.sectionHeadCta}`}
                             >
-                                S'abonner
+                                <Translate id="premium.cta.subscribe">S'abonner</Translate>
                             </Link>
                         </div>
                         <div className={styles.grid}>
@@ -430,7 +455,9 @@ export default function PremiumPage(): React.ReactNode {
                                     <p className={styles.featureDesc}>{exp.description}</p>
                                     {exp.docsHref && (
                                         <div className={styles.featureMeta}>
-                                            <Link to={exp.docsHref}>En savoir plus →</Link>
+                                            <Link to={exp.docsHref}>
+                                                <Translate id="premium.experiment.learnMore">En savoir plus →</Translate>
+                                            </Link>
                                         </div>
                                     )}
                                 </article>
@@ -443,12 +470,16 @@ export default function PremiumPage(): React.ReactNode {
                 <section id="compare" className={styles.section}>
                     <div className={styles.container}>
                         <div>
-                            <span className={styles.sectionEyebrow}>Comparatif des offres</span>
-                            <h2 className={styles.sectionTitle}>Choisissez l'offre qui vous correspond</h2>
+                            <span className={styles.sectionEyebrow}>
+                                <Translate id="premium.compare.eyebrow">Comparatif des offres</Translate>
+                            </span>
+                            <h2 className={styles.sectionTitle}>
+                                <Translate id="premium.compare.title">Choisissez l'offre qui vous correspond</Translate>
+                            </h2>
                             <p className={styles.sectionSubtitle}>
-                                Toutes les protections essentielles restent gratuites. Le Premium ouvre
-                                la personnalisation et les limites étendues. Le Business apporte une
-                                instance dédiée et un accompagnement humain.
+                                <Translate id="premium.compare.subtitle">
+                                    Toutes les protections essentielles restent gratuites. Le Premium ouvre la personnalisation et les limites étendues. Le Business apporte une instance dédiée et un accompagnement humain.
+                                </Translate>
                             </p>
                         </div>
 
@@ -596,10 +627,16 @@ export default function PremiumPage(): React.ReactNode {
                 {/* ============= FINAL CTA ============= */}
                 <section className={styles.container}>
                     <div className={styles.finalCta}>
-                        <h2>Prêt à passer en Premium&nbsp;?</h2>
-                        <p>L'offre Founder est limitée dans le temps : 2,99 $/mois à vie pour les premiers abonnés.</p>
+                        <h2>
+                            <Translate id="premium.finalCta.title">Prêt à passer en Premium&nbsp;?</Translate>
+                        </h2>
+                        <p>
+                            <Translate id="premium.finalCta.subtitle">
+                                L'offre Founder est limitée dans le temps : 2,99 $/mois à vie pour les premiers abonnés.
+                            </Translate>
+                        </p>
                         <Link to="https://raidprotect.bot/founder" className={`${styles.ctaPrimary} ${styles.ctaGlow}`}>
-                            Activer le Premium maintenant
+                            <Translate id="premium.finalCta.cta">Activer le Premium maintenant</Translate>
                         </Link>
                     </div>
                 </section>


### PR DESCRIPTION
## Résumé
Internationalise entièrement la page `/premium`, qui était codée en dur en français.

- Toutes les chaînes passent par `<Translate>` / `translate()` (89 clés `premium.*`).
- Les tableaux de données (features, expériences, offres, comparatif) sont construits au rendu pour que `translate()` lise la locale courante.
- Traductions complètes : **en, de, es, pt** (+ fr par défaut).
- Le prix Founder est rendu traduisible pour adapter le format par langue (`$2.99` en EN, `2,99 $` ailleurs) et rester cohérent avec les CTA.

## Notes
`write-translations` a resynchronisé deux éléments annexes, sans toucher aux traductions existantes :
- ajout de la clé navbar `item.label.Premium` (le bouton Premium n'avait jamais été extrait) ;
- mise à jour de `description` dans les `footer.json` (cibles de liens).

## Vérifs
- `pnpm typecheck` ✅
- 89/89 clés traduites par locale, aucune clé manquante ni orpheline.