### PR TITLE
feat(navbar): boutons « Ajouter le bot » + « Support » et sélecteur de langue compact

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -276,6 +276,10 @@ export default async function createConfigAsync() {
                         rel: 'noopener noreferrer',
                     },
                     {
+                        type: 'localeDropdown',
+                        position: 'right',
+                    },
+                    {
                         // Redirection du domaine vers le flux d'ajout OAuth. URL
                         // absolue : lien externe (pas de vérification de lien
                         // cassé) et invitation identique quelle que soit la langue
@@ -289,10 +293,6 @@ export default async function createConfigAsync() {
                         to: '/premium',
                         label: 'Premium',
                         className: 'navbar-premium',
-                        position: 'right',
-                    },
-                    {
-                        type: 'localeDropdown',
                         position: 'right',
                     }
                 ],

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -270,6 +270,7 @@ export default async function createConfigAsync() {
                     {
                         href: 'https://discord.com/invite/raidprotect',
                         label: 'Support',
+                        className: 'navbar-no-ext',
                         position: 'left',
                         target: '_blank',
                         rel: 'noopener noreferrer',
@@ -281,7 +282,7 @@ export default async function createConfigAsync() {
                         // de l'interface.
                         href: 'https://raidprotect.bot/invite',
                         label: 'Ajouter le bot',
-                        className: 'navbar-addbot',
+                        className: 'navbar-addbot navbar-no-ext',
                         position: 'right',
                     },
                     {

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -270,8 +270,7 @@ export default async function createConfigAsync() {
                     {
                         href: 'https://discord.com/invite/raidprotect',
                         label: 'Support',
-                        className: 'navbar-support',
-                        position: 'right',
+                        position: 'left',
                         target: '_blank',
                         rel: 'noopener noreferrer',
                     },

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -268,23 +268,31 @@ export default async function createConfigAsync() {
                         label: 'Blog',
                     },
                     {
-                        type: 'localeDropdown',
+                        href: 'https://discord.com/invite/raidprotect',
+                        label: 'Support',
+                        className: 'navbar-support',
                         position: 'right',
-                        // dropdownItemsAfter: [
-                        //     {
-                        //         type: 'html',
-                        //         value: '<hr style="margin: 0.3rem 0;">',
-                        //     },
-                        //     {
-                        //         href: 'https://github.com/facebook/docusaurus/issues/3526',
-                        //         label: 'Help Us Translate',
-                        //     },
-                        // ],
+                        target: '_blank',
+                        rel: 'noopener noreferrer',
+                    },
+                    {
+                        // Redirection du domaine vers le flux d'ajout OAuth. URL
+                        // absolue : lien externe (pas de vérification de lien
+                        // cassé) et invitation identique quelle que soit la langue
+                        // de l'interface.
+                        href: 'https://raidprotect.bot/invite',
+                        label: 'Ajouter le bot',
+                        className: 'navbar-addbot',
+                        position: 'right',
                     },
                     {
                         to: '/premium',
                         label: 'Premium',
                         className: 'navbar-premium',
+                        position: 'right',
+                    },
+                    {
+                        type: 'localeDropdown',
                         position: 'right',
                     }
                 ],

--- a/i18n/de/docusaurus-theme-classic/navbar.json
+++ b/i18n/de/docusaurus-theme-classic/navbar.json
@@ -22,5 +22,13 @@
   "item.label.Premium": {
     "message": "Premium",
     "description": "Navbar item with label Premium"
+  },
+  "item.label.Support": {
+    "message": "Support",
+    "description": "Navbar item with label Support"
+  },
+  "item.label.Ajouter le bot": {
+    "message": "Bot hinzufügen",
+    "description": "Navbar item with label Ajouter le bot"
   }
 }

--- a/i18n/en/docusaurus-theme-classic/navbar.json
+++ b/i18n/en/docusaurus-theme-classic/navbar.json
@@ -22,5 +22,13 @@
   "item.label.Premium": {
     "message": "Premium",
     "description": "Navbar item with label Premium"
+  },
+  "item.label.Support": {
+    "message": "Support",
+    "description": "Navbar item with label Support"
+  },
+  "item.label.Ajouter le bot": {
+    "message": "Add the bot",
+    "description": "Navbar item with label Ajouter le bot"
   }
 }

--- a/i18n/es/docusaurus-theme-classic/navbar.json
+++ b/i18n/es/docusaurus-theme-classic/navbar.json
@@ -22,5 +22,13 @@
   "item.label.Premium": {
     "message": "Premium",
     "description": "Navbar item with label Premium"
+  },
+  "item.label.Support": {
+    "message": "Soporte",
+    "description": "Navbar item with label Support"
+  },
+  "item.label.Ajouter le bot": {
+    "message": "Añadir el bot",
+    "description": "Navbar item with label Ajouter le bot"
   }
 }

--- a/i18n/fr/docusaurus-theme-classic/navbar.json
+++ b/i18n/fr/docusaurus-theme-classic/navbar.json
@@ -22,5 +22,13 @@
   "item.label.Premium": {
     "message": "Premium",
     "description": "Navbar item with label Premium"
+  },
+  "item.label.Support": {
+    "message": "Support",
+    "description": "Navbar item with label Support"
+  },
+  "item.label.Ajouter le bot": {
+    "message": "Ajouter le bot",
+    "description": "Navbar item with label Ajouter le bot"
   }
 }

--- a/i18n/pt/docusaurus-theme-classic/navbar.json
+++ b/i18n/pt/docusaurus-theme-classic/navbar.json
@@ -22,5 +22,13 @@
   "item.label.Premium": {
     "message": "Premium",
     "description": "Navbar item with label Premium"
+  },
+  "item.label.Support": {
+    "message": "Suporte",
+    "description": "Navbar item with label Support"
+  },
+  "item.label.Ajouter le bot": {
+    "message": "Adicionar o bot",
+    "description": "Navbar item with label Ajouter le bot"
   }
 }

--- a/src/components/SidebarVersionSelect/styles.module.css
+++ b/src/components/SidebarVersionSelect/styles.module.css
@@ -45,8 +45,10 @@
   background-color: var(--ifm-color-emphasis-200);
 }
 
+/* Même rouge que le fond de l'announcement bar (#BD5454) : plus foncé que
+   --ifm-color-primary, pour un contraste suffisant avec le texte blanc. */
 .segmentActive,
 .segmentActive:hover {
   color: #fff;
-  background-color: var(--ifm-color-primary);
+  background-color: #BD5454;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -152,6 +152,59 @@ body.premium-page::before {
   filter: brightness(1.06);
 }
 
+/* Bouton "Ajouter le bot" : CTA principal, pilule pleine (blurple Discord). */
+.navbar__link.navbar-addbot {
+  margin-left: 0.4rem;
+  padding: 0.42rem 1.1rem;
+  border-radius: 999px;
+  color: #fff;
+  font-weight: 600;
+  background: #5865f2;
+  box-shadow: 0 8px 22px -10px rgba(88, 101, 242, 0.7);
+  transition: transform .2s ease, box-shadow .2s ease, filter .2s ease;
+}
+
+.navbar__link.navbar-addbot:hover {
+  color: #fff;
+  text-decoration: none;
+  transform: translateY(-1px);
+  filter: brightness(1.07);
+  box-shadow: 0 12px 28px -10px rgba(88, 101, 242, 0.8);
+}
+
+/* Lien "Support" : action secondaire discrète, contour léger. */
+.navbar__link.navbar-support {
+  padding: 0.42rem 0.95rem;
+  border-radius: 999px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  transition: border-color .2s ease, color .2s ease;
+}
+
+.navbar__link.navbar-support:hover {
+  text-decoration: none;
+  border-color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary);
+}
+
+/* Variantes dans le menu mobile (sidebar). */
+.menu__link.navbar-addbot {
+  margin-top: 0.5rem;
+  border-radius: 999px;
+  color: #fff;
+  background: #5865f2;
+}
+
+.menu__link.navbar-addbot:hover {
+  color: #fff;
+  filter: brightness(1.07);
+}
+
+.menu__link.navbar-support {
+  margin-top: 0.5rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 999px;
+}
+
 .navbar-social {
   padding: 0;
   margin-left: 1rem;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -403,9 +403,28 @@ body:not(.editor-page) [class*="expandButton"] {
 }
 
 @media screen and (min-width: 997px) {
+  /* Aligne le contenu de la navbar sur le même container centré (1140px) que le
+     footer : le logo et les items à droite partagent exactement la gouttière de
+     .container, donc le logo navbar et le logo footer ont la même position. */
+  .navbar {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  .navbar__inner {
+    position: relative;
+    max-width: var(--ifm-container-width);
+    margin-left: auto;
+    margin-right: auto;
+    padding-left: var(--ifm-spacing-horizontal);
+    padding-right: var(--ifm-spacing-horizontal);
+  }
+
+  /* left:1rem est désormais relatif à .navbar__inner (positionné), donc le logo
+     s'aligne sur le bord gauche du container, comme le logo du footer. */
   .navbar__brand {
     position: absolute;
-    left: 1rem;
+    left: var(--ifm-spacing-horizontal);
     top: 50%;
     transform: translateY(-50%);
   }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -172,6 +172,11 @@ body.premium-page::before {
   box-shadow: 0 12px 28px -10px rgba(88, 101, 242, 0.8);
 }
 
+/* Masque la petite icône "lien externe" sur Support et Ajouter le bot. */
+.navbar-no-ext svg[class*='iconExternalLink'] {
+  display: none;
+}
+
 /* Variante "Ajouter le bot" dans le menu mobile (sidebar). */
 .menu__link.navbar-addbot {
   margin-top: 0.5rem;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -172,21 +172,7 @@ body.premium-page::before {
   box-shadow: 0 12px 28px -10px rgba(88, 101, 242, 0.8);
 }
 
-/* Lien "Support" : action secondaire discrète, contour léger. */
-.navbar__link.navbar-support {
-  padding: 0.42rem 0.95rem;
-  border-radius: 999px;
-  border: 1px solid var(--ifm-color-emphasis-300);
-  transition: border-color .2s ease, color .2s ease;
-}
-
-.navbar__link.navbar-support:hover {
-  text-decoration: none;
-  border-color: var(--ifm-color-primary);
-  color: var(--ifm-color-primary);
-}
-
-/* Variantes dans le menu mobile (sidebar). */
+/* Variante "Ajouter le bot" dans le menu mobile (sidebar). */
 .menu__link.navbar-addbot {
   margin-top: 0.5rem;
   border-radius: 999px;
@@ -197,12 +183,6 @@ body.premium-page::before {
 .menu__link.navbar-addbot:hover {
   color: #fff;
   filter: brightness(1.07);
-}
-
-.menu__link.navbar-support {
-  margin-top: 0.5rem;
-  border: 1px solid var(--ifm-color-emphasis-300);
-  border-radius: 999px;
 }
 
 .navbar-social {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -435,3 +435,31 @@ body:not(.editor-page) [class*="expandButton"] {
     grid-row-gap: 20px;
   }
 }
+
+/* Palier intermédiaire (tablette large / petit laptop) : avant le passage en
+   menu hamburger (<997px), la navbar a beaucoup d'items. On réduit le logo, la
+   taille des liens et le padding des boutons pour que "Accueil" ne chevauche
+   plus le logo. */
+@media screen and (min-width: 997px) and (max-width: 1200px) {
+  .navbar__brand .navbar__logo img {
+    width: 196px;
+    height: auto;
+  }
+
+  .navbar__items:not(.navbar__items--right) {
+    margin-left: 200px;
+  }
+
+  .navbar__item {
+    font-size: 15px;
+    padding-left: 7px;
+    padding-right: 7px;
+  }
+
+  .navbar__link.navbar-addbot,
+  .navbar__link.navbar-premium {
+    margin-left: 0.3rem;
+    padding: 0.34rem 0.72rem;
+    font-size: 14px;
+  }
+}

--- a/src/pages/premium.tsx
+++ b/src/pages/premium.tsx
@@ -329,7 +329,7 @@ export default function PremiumPage(): React.ReactNode {
             <Head>
                 <body className="premium-page" />
             </Head>
-            <div className={styles.page}>
+            <main className={styles.page}>
                 {/* ============= HERO ============= */}
                 <section className={styles.hero}>
                     <div className={styles.container}>
@@ -640,7 +640,7 @@ export default function PremiumPage(): React.ReactNode {
                         </Link>
                     </div>
                 </section>
-            </div>
+            </main>
         </Layout>
     )
 }

--- a/src/theme/NavbarItem/LocaleDropdownNavbarItem/index.tsx
+++ b/src/theme/NavbarItem/LocaleDropdownNavbarItem/index.tsx
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Swizzle (eject) : en desktop, le déclencheur du sélecteur de langue n'affiche
+ * que le code de la locale (FR, EN, …) pour rester compact dans la navbar ; le
+ * menu déroulant garde les noms complets. Le mobile reste inchangé (« Langues »).
+ */
+
+import React, {type ReactNode} from 'react';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import {useAlternatePageUtils} from '@docusaurus/theme-common/internal';
+import {translate} from '@docusaurus/Translate';
+import {mergeSearchStrings, useHistorySelector} from '@docusaurus/theme-common';
+import DropdownNavbarItem from '@theme/NavbarItem/DropdownNavbarItem';
+import IconLanguage from '@theme/Icon/Language';
+import type {Props} from '@theme/NavbarItem/LocaleDropdownNavbarItem';
+
+import styles from './styles.module.css';
+
+function useLocaleDropdownUtils() {
+  const {
+    siteConfig,
+    i18n: {localeConfigs},
+  } = useDocusaurusContext();
+  const alternatePageUtils = useAlternatePageUtils();
+  const search = useHistorySelector((history) => history.location.search);
+  const hash = useHistorySelector((history) => history.location.hash);
+  const getLocaleConfig = (locale: string) => {
+    const localeConfig = localeConfigs[locale];
+    if (!localeConfig) {
+      throw new Error(
+        `Docusaurus bug, no locale config found for locale=${locale}`,
+      );
+    }
+    return localeConfig;
+  };
+  const getBaseURLForLocale = (locale: string) => {
+    const localeConfig = getLocaleConfig(locale);
+    const isSameDomain = localeConfig.url === siteConfig.url;
+    if (isSameDomain) {
+      return `pathname://${alternatePageUtils.createUrl({
+        locale,
+        fullyQualified: false,
+      })}`;
+    }
+    return alternatePageUtils.createUrl({
+      locale,
+      fullyQualified: true,
+    });
+  };
+  return {
+    getURL: (locale: string, options: {queryString?: string}) => {
+      const finalSearch = mergeSearchStrings(
+        [search, options.queryString],
+        'append',
+      );
+      return `${getBaseURLForLocale(locale)}${finalSearch}${hash}`;
+    },
+    getLabel: (locale: string) => getLocaleConfig(locale).label,
+    getLang: (locale: string) => getLocaleConfig(locale).htmlLang,
+  };
+}
+
+export default function LocaleDropdownNavbarItem({
+  mobile,
+  dropdownItemsBefore,
+  dropdownItemsAfter,
+  queryString,
+  ...props
+}: Props): ReactNode {
+  const utils = useLocaleDropdownUtils();
+  const {
+    i18n: {currentLocale, locales},
+  } = useDocusaurusContext();
+
+  const localeItems = locales.map((locale) => ({
+    label: utils.getLabel(locale),
+    lang: utils.getLang(locale),
+    to: utils.getURL(locale, {queryString}),
+    target: '_self',
+    autoAddBaseUrl: false,
+    className:
+      // eslint-disable-next-line no-nested-ternary
+      locale === currentLocale
+        ? mobile
+          ? 'menu__link--active'
+          : 'dropdown__link--active'
+        : '',
+  }));
+
+  const items = [...dropdownItemsBefore, ...localeItems, ...dropdownItemsAfter];
+
+  // Mobile : libellé générique « Langues » (le menu liste les noms complets).
+  // Desktop : on n'affiche que le code de la locale courante (FR, EN, …).
+  const dropdownLabel = mobile
+    ? translate({
+        message: 'Languages',
+        id: 'theme.navbar.mobileLanguageDropdown.label',
+        description: 'The label for the mobile language switcher dropdown',
+      })
+    : currentLocale.toUpperCase();
+
+  return (
+    <DropdownNavbarItem
+      {...props}
+      mobile={mobile}
+      label={
+        <>
+          <IconLanguage className={styles.iconLanguage} />
+          {dropdownLabel}
+        </>
+      }
+      items={items}
+    />
+  );
+}

--- a/src/theme/NavbarItem/LocaleDropdownNavbarItem/styles.module.css
+++ b/src/theme/NavbarItem/LocaleDropdownNavbarItem/styles.module.css
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.iconLanguage {
+  vertical-align: text-bottom;
+  margin-right: 5px;
+}


### PR DESCRIPTION
## Résumé
Trois ajouts à la navbar demandés :

1. **Bouton « Ajouter le bot »** — CTA principal (pilule blurple Discord) vers le flux d'ajout OAuth (`raidprotect.bot/invite`).
2. **Bouton « Support »** — vers le serveur Discord (`discord.com/invite/raidprotect`), style ghost discret.
3. **Sélecteur de langue compact** — en desktop, le déclencheur n'affiche plus que le **code** de la locale (🌐 FR, EN…) ; le menu déroulant conserve les **noms complets** (Français, English…). Le mobile reste inchangé (« Langues »).

## Détails techniques
- Les deux boutons sont des items de **config** (`navbar.items`), donc rendus à la fois en desktop **et** dans la sidebar mobile. Labels traduits en en/de/es/pt.
- Le code de langue vient d'un **swizzle (eject)** de `LocaleDropdownNavbarItem` : seul le libellé desktop devient `currentLocale.toUpperCase()`, le reste (liens, menu, mobile) est identique à l'original.
- L'URL d'invitation est **absolue** (lien externe) pour éviter ~50 avertissements de liens cassés au build : la cible est une redirection de domaine, et l'invitation OAuth est la même quelle que soit la langue de l'interface.
- Styles dédiés `.navbar-addbot` / `.navbar-support` (desktop + variantes `.menu__link` mobile).

## Vérifs
- `pnpm typecheck` ✅
- `pnpm build` ✅ sur les 5 locales, **0 avertissement de lien cassé**
- Rendu vérifié dans le HTML généré : déclencheur « 🌐 FR » + menu noms complets, labels traduits par locale.
