### PR TITLE
fix(seo): restaurer le canonical bêta → stable

### DIFF
--- a/src/theme/SiteMetadata/index.tsx
+++ b/src/theme/SiteMetadata/index.tsx
@@ -98,17 +98,40 @@ function AlternateLangHeaders(): ReactNode {
 // Default canonical url inferred from current page location pathname
 function useDefaultCanonicalUrl() {
   const {
-    siteConfig: {url: siteUrl, baseUrl, trailingSlash},
+    siteConfig: {
+      url: siteUrl,
+      baseUrl,
+      trailingSlash,
+      customFields: {excludedCanonical},
+    },
   } = useDocusaurusContext();
 
   // TODO using useLocation().pathname is not a super idea
   // See https://github.com/facebook/docusaurus/issues/9170
   const {pathname} = useLocation();
 
-  const canonicalPathname = applyTrailingSlash(useBaseUrl(pathname), {
+  let canonicalPathname = applyTrailingSlash(useBaseUrl(pathname), {
     trailingSlash,
     baseUrl,
   });
+
+  // Les pages de la doc bêta (/docs/beta/…, et /<locale>/docs/beta/…) sont
+  // canonicalisées vers leur équivalent stable (/docs/…, servi à la racine de la
+  // version) pour éviter le contenu dupliqué bêta/stable côté SEO. La langue est
+  // préservée. Les chemins listés dans customFields.excludedCanonical (pages
+  // exclusives à la bêta) gardent leur propre canonical.
+  const betaPathRegex = /^(\/(?:en|de|es|pt))?\/docs\/beta(\/|$)/;
+
+  if (
+    betaPathRegex.test(canonicalPathname) &&
+    !(excludedCanonical as string[]).includes(pathname)
+  ) {
+    canonicalPathname = canonicalPathname.replace(
+      betaPathRegex,
+      (_match: string, lang: string | undefined, tail: string) =>
+        `${lang ?? ''}/docs${tail}`,
+    );
+  }
 
   return siteUrl + canonicalPathname;
 }


### PR DESCRIPTION
## Contexte
La réécriture du `<link rel="canonical">` des pages de doc **bêta** vers leur équivalent **stable** existait, puis a été supprimée lors du commit `feat: 3.3.3` (`4ce1e6c`). Il ne restait que le champ `excludedCanonical: []` (inutilisé).

## Changement
Restaure la logique dans `SiteMetadata` :
- les pages `/docs/beta/…` (et `/<locale>/docs/beta/…`) ont leur **canonical + og:url** pointant vers `/docs/…` (stable, servi à la racine de version) ;
- la **langue est préservée** (`/en/docs/beta/x` → `/en/docs/x`) ;
- réutilise `customFields.excludedCanonical` pour exclure d'éventuelles pages exclusives à la bêta ;
- **regex adaptée à la route actuelle** : `/docs/beta` (l'ancienne visait `/beta`, la route a changé depuis).

## Vérifié au build (5 locales)
| Page | Canonical |
|------|-----------|
| `/docs/setup` (stable) | `…/docs/setup` (elle-même) |
| `/docs/beta/setup` | `…/docs/setup` |
| `/en/docs/beta/setup` | `…/en/docs/setup` |
| `/de/docs/beta/features` | `…/de/docs/features` |
| `/` (home) | `…/` (inchangée) |

`pnpm typecheck` ✅ · `pnpm build` ✅