### PR TITLE
feat(navbar): localiser le lien « Ajouter le bot »

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -69,6 +69,15 @@ export default async function createConfigAsync() {
                     es: '/es/',
                     pt: '/pt/'
                 },
+                invite: {
+                    // URLs absolues (redirections du domaine) : localisées par
+                    // langue et non vérifiées par le broken-links checker.
+                    fr: 'https://raidprotect.bot/invite',
+                    en: 'https://raidprotect.bot/en/invite',
+                    de: 'https://raidprotect.bot/de/invite',
+                    es: 'https://raidprotect.bot/es/invite',
+                    pt: 'https://raidprotect.bot/pt/invite'
+                },
                 geranium: {
                     fr: 'https://i.dfr.gg/geranium.webm',
                     en: 'https://i.dfr.gg/en-geranium.webm',
@@ -280,11 +289,11 @@ export default async function createConfigAsync() {
                         position: 'right',
                     },
                     {
-                        // Redirection du domaine vers le flux d'ajout OAuth. URL
-                        // absolue : lien externe (pas de vérification de lien
-                        // cassé) et invitation identique quelle que soit la langue
-                        // de l'interface.
-                        href: 'https://raidprotect.bot/invite',
+                        // Redirection du domaine vers le flux d'ajout OAuth.
+                        // `to: 'invite'` est résolu par locale via customFields.urls
+                        // (URLs absolues localisées : /invite, /en/invite, …) dans
+                        // les swizzles Navbar/Content et MobileSidebar/PrimaryMenu.
+                        to: 'invite',
                         label: 'Ajouter le bot',
                         className: 'navbar-addbot navbar-no-ext',
                         position: 'right',

--- a/src/theme/Navbar/Content/index.tsx
+++ b/src/theme/Navbar/Content/index.tsx
@@ -20,6 +20,7 @@ import NavbarSearch from '@theme/Navbar/Search';
 
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
+import {localizeNavbarItemUrl} from '@site/src/utils/links';
 import styles from './styles.module.css';
 
 function useNavbarItems() {
@@ -73,6 +74,14 @@ export default function NavbarContent(): ReactNode {
   const items = useNavbarItems();
   const [leftItems, rightItems] = splitNavbarItems(items);
 
+  // Localise les items dont le `to` est une clé de customFields.urls (main, invite…).
+  const localize = (i: NavbarItemConfig) =>
+    localizeNavbarItemUrl(
+      i,
+      urls as Record<string, Record<string, string>>,
+      currentLocale,
+    );
+
   const searchBarItem = items.find((item) => item.type === 'search');
 
   return (
@@ -82,23 +91,14 @@ export default function NavbarContent(): ReactNode {
         <>
           {!mobileSidebar.disabled && <NavbarMobileSidebarToggle />}
           <NavbarLogo />
-          <NavbarItems items={leftItems.map(i => {
-            if (i['to'] && urls[i['to']]) {
-              const localizedPath = urls[i['to']][currentLocale] ?? i['to']
-              i['to'] = localizedPath
-              // Sans cela, un to="/" matche toutes les routes et le bouton reste actif partout.
-              const escaped = localizedPath.replace(/\/$/, '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-              i['activeBaseRegex'] = `^${escaped || ''}/?$`
-            }
-            return i
-          })} />
+          <NavbarItems items={leftItems.map(localize)} />
         </>
       }
       right={
         // TODO stop hardcoding items?
         // Ask the user to add the respective navbar items => more flexible
         <>
-          <NavbarItems items={rightItems} />
+          <NavbarItems items={rightItems.map(localize)} />
           <NavbarColorModeToggle className={styles.colorModeToggle} />
           {!searchBarItem && (
             <NavbarSearch>

--- a/src/theme/Navbar/MobileSidebar/PrimaryMenu/index.tsx
+++ b/src/theme/Navbar/MobileSidebar/PrimaryMenu/index.tsx
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Swizzle (eject) : applique la localisation des items dont le `to` est une clé
+ * de customFields.urls (main, invite…), comme le swizzle Navbar/Content le fait
+ * pour la navbar desktop. Sans ça, le menu mobile rendrait `to="invite"` tel
+ * quel (lien cassé).
+ */
+
+import React, {type ReactNode} from 'react';
+import {useThemeConfig} from '@docusaurus/theme-common';
+import {useNavbarMobileSidebar} from '@docusaurus/theme-common/internal';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import NavbarItem, {type Props as NavbarItemConfig} from '@theme/NavbarItem';
+
+import {localizeNavbarItemUrl} from '@site/src/utils/links';
+
+function useNavbarItems() {
+  // TODO temporary casting until ThemeConfig type is improved
+  return useThemeConfig().navbar.items as NavbarItemConfig[];
+}
+
+// The primary menu displays the navbar items
+export default function NavbarMobilePrimaryMenu(): ReactNode {
+  const mobileSidebar = useNavbarMobileSidebar();
+  const {
+    siteConfig: {
+      customFields: {urls},
+    },
+    i18n: {currentLocale},
+  } = useDocusaurusContext();
+
+  const items = useNavbarItems();
+
+  return (
+    <ul className="menu__list">
+      {items.map((item, i) => (
+        <NavbarItem
+          mobile
+          {...localizeNavbarItemUrl(
+            item,
+            urls as Record<string, Record<string, string>>,
+            currentLocale,
+          )}
+          onClick={() => mobileSidebar.toggle()}
+          key={i}
+        />
+      ))}
+    </ul>
+  );
+}

--- a/src/utils/links.ts
+++ b/src/utils/links.ts
@@ -21,3 +21,34 @@ export function localizedRedirectUrl(
   const prefix = currentLocale === defaultLocale ? '' : `/${currentLocale}`;
   return `${siteUrl}${prefix}${path}`;
 }
+
+type UrlsMap = Record<string, Record<string, string>>;
+
+/**
+ * Localise un item de navbar dont le `to` est une clé de `customFields.urls`
+ * (ex: `main`, `invite`) : remplace la clé par l'URL de la locale courante.
+ *
+ * Renvoie une copie (pas de mutation de l'objet de config, partagé entre les
+ * rendus desktop et mobile). Pour un chemin interne, on cadre l'état « actif »
+ * sur l'URL exacte (sinon un `to="/"` matcherait toutes les routes) ; pour une
+ * URL absolue (lien externe, ex: redirection de domaine), pas d'état actif.
+ */
+export function localizeNavbarItemUrl<T>(
+  item: T,
+  urls: UrlsMap,
+  currentLocale: string,
+): T {
+  const key = (item as {to?: string}).to;
+  if (!key || !urls[key]) {
+    return item;
+  }
+  const resolved = urls[key][currentLocale] ?? key;
+  const next = {...item, to: resolved} as T & {activeBaseRegex?: string};
+  if (resolved.startsWith('/')) {
+    const escaped = resolved
+      .replace(/\/$/, '')
+      .replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    next.activeBaseRegex = `^${escaped || ''}/?$`;
+  }
+  return next;
+}


### PR DESCRIPTION
## Changement
Le bouton **« Ajouter le bot »** de la navbar pointe désormais vers l'invite **localisée** selon la langue, au lieu d'une URL unique :

| Locale | href |
|--------|------|
| fr | `https://raidprotect.bot/invite` |
| en | `https://raidprotect.bot/en/invite` |
| de | `https://raidprotect.bot/de/invite` |
| es | `https://raidprotect.bot/es/invite` |
| pt | `https://raidprotect.bot/pt/invite` |

## Mécanisme
- `customFields.urls.invite` : map des URLs **absolues localisées** (même convention que `urls.main`). Absolues ⇒ liens externes ⇒ **pas vérifiées par le broken-links checker**.
- L'item passe en `to: 'invite'` (clé de la map).
- Helper `localizeNavbarItemUrl` (dans `src/utils/links.ts`) qui résout la clé selon la locale, sans muter l'objet de config.
- Appliqué dans le swizzle **`Navbar/Content`** (desktop, étendu aux items de droite) **et** un nouveau swizzle **`Navbar/MobileSidebar/PrimaryMenu`** (le menu mobile ne passe pas par Navbar/Content).

## Vérifs
- `pnpm typecheck` ✅
- `pnpm build` ✅ sur les 5 locales, **0 avertissement de lien cassé**
- href rendu vérifié par locale (extraction du HTML généré).